### PR TITLE
Add Veeva Vault API OpenAPI spec

### DIFF
--- a/veeva_vault/openapi.yaml
+++ b/veeva_vault/openapi.yaml
@@ -1,0 +1,28061 @@
+openapi: 3.0.0
+info:
+  title: Veeva Vault API v25.1
+  description: The latest GA version of the Vault REST API.
+  version: 1.0.0
+servers:
+  - url: https://{{vaultDNS}}
+  - url: https://login.veevavault.com
+tags:
+  - name: Authentication
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Authentication
+
+
+
+      Authenticate your account using one of the methods outlined below. The
+      response returns a session ID that you can use in subsequent API calls.
+      Session IDs time out after a period of inactivity, which varies by Vault.
+      Learn more about <a
+      href="https://developer.veevavault.com/docs/#Session_Mangement">session
+      duration and management</a>.
+
+
+      After acquiring a Vault Session ID, include it on every subsequent API
+      call inside the `Authorization` HTTP request header.
+
+
+      #### Basic Authorization
+
+
+      |Name          |Description                                |
+
+      |:-------------|:------------------------------------------|
+
+      |`Authorization`|{`sessionId`}|
+
+
+      Alternatively, you can use Salesforce&trade; or OAuth2/OIDC Delegated
+      Requests.
+
+
+      The Vault API also accepts Vault Session IDs as Bearer tokens. Include
+      `Bearer` keyword to send Vault Session IDs with as bearer tokens:
+
+
+      #### Bearer Token Authorization
+
+
+      |Name          |Description                                |
+
+      |:-------------|:------------------------------------------|
+
+      |`Authorization`|Bearer {`sessionId`}|
+
+  - name: Authentication > Delegated Access
+    description: "Vault’s delegated access feature provides a secure and audited process for you to designate another user to handle Vault responsibilities on your behalf. Vault tracks all activities performed by the delegate and logs their activities in audit trails that meet compliance standards. Learn more <a href=\"https://platform.veevavault.help/en/lr/15015\">about\_delegated access in Vault Help</a>.\n\nWith the Vault REST API’s delegated access endpoints, you can generate a delegated session ID for any Vaults where you have delegate access. This allows you to call the Vault REST API on behalf of any user who granted you delegate access. For example, a user may grant delegate access to an IT professional for help troubleshooting a problem. Your organization may also utilize delegate access for shared accounts, such as a “Migration User.”\n\nDelegation is Vault-specific: If your IT professional needs access to both your PromoMats and Submissions Vaults, you will need to grant them delegate access in both Vaults."
+  - name: Direct Data
+    description: >-
+      [https://developer.veevavault.com/api/25.1/#Direct_Data](https://developer.veevavault.com/api/25.1/#Vault_Java_SDK)
+
+
+      The Direct Data API provides high-speed read-only data access to Vault.
+      The following endpoints allow you to retrieve available Direct Data files
+      and download them. Learn more about the [Direct Data
+      API](https://developer.veevavault.com/directdata).
+
+
+      Your security profile and permission set must grant the _Access_ and
+      _Direct Data_ permissions for the Vault REST API.
+
+
+      Direct Data API is not enabled by default. You must contact your Veeva
+      representative to enable it in your Vault. Veeva EDC supports Study File
+      Format instead of Direct Data API. For more information, see the [Clinical
+      Data Veeva Developer
+      Portal](https://developer-cdms.veevavault.com/cdb-api/24.3/#study-file-format).
+  - name: Vault Query Language (VQL)
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Vault_Query_Language
+
+
+
+      When an application invokes a query call, it passes in a **Vault Query
+      Language (VQL)** statement (a SQL-like statement) that specifies the
+      object to query (in the `FROM` clause), the fields to retrieve (in the
+      `SELECT` clause), and any optional filters to apply (in the `WHERE` and
+      `FIND` clauses) to narrow your results.  Learn more in the <a
+      href="https://developer.veevavault.com/vql">VQL documentation</a>.
+
+  - name: Metadata Definition Language (MDL)
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Metadata_Definition_Language
+
+
+
+      Vault is configured with a set of <a
+      href="https://developer.veevavault.com/mdl/components">component types</a>
+      that make up its configuration elements. Use MDL to create, describe
+      (read), update, and drop (delete) Vault components and manage its
+      configuration. Learn more in our <a
+      href="https://developer.veevavault.com/mdl/#Intro_MDL">MDL</a>
+      documentation.
+
+  - name: Metadata Definition Language (MDL) > Retrieve Component Records
+    description: |+
+      https://developer.veevavault.com/api/25.1/#Retrieve_Component_Records
+
+  - name: Metadata Definition Language (MDL) > Components with Content
+    description: >-
+      [https://developer.veevavault.com/api/25.1/#Components_With_Content](https://developer.veevavault.com/api/25.1/#Components_With_Content)
+
+
+      The following Vault component types contain binary content as part of
+      their definition:
+
+
+      - `Formattedoutput`
+          
+      - `Overlaytemplate`
+          
+      - `Signaturepage`
+          
+
+      The following endpoints allow you to upload, reference, and migrate the
+      binary content of a file.
+  - name: Metadata Definition Language (MDL) > Asynchronous MDL Requests
+    description: >-
+      https://developer.veevavault.com/api/25.1/#Execute_MDL_Async_Top
+
+
+      Instead of a [synchronous
+      request](https://developer.veevavault.com/api/25.1/#Execute_MDL), you must
+      use an [asynchronous
+      request](https://developer.veevavault.com/api/25.1/#Execute_MDL_Async) if
+      you are executing one of the following operations on 10,000+ `raw` object
+      records:
+
+
+      - Enabling lifecycles
+          
+      - Enabling or disabling object types
+          
+      - Adding or removing a field
+          
+      - Updating the max length of any variable-length field, such as _Text_,
+      _Long Text_, or _Rich Text_
+          
+      - Adding or removing an `Index`
+          
+      - Changing the fields that compose an `Index` or otherwise would cause
+      reindexing to occur
+          
+
+      A raw object is a Vault object where the `data_store` attribute is set to
+      `raw`. To determine if an object is a raw object, retrieve the value of
+      the `data_store` parameter from the [Retrieve Object
+      Metadata](https://developer.veevavault.com/api/25.1/#Retrieve_Object_Metadata)
+      endpoint. Learn more about [raw objects in Vault
+      Help](https://platform.veevavault.help/en/lr/62987/).
+
+
+      After initiating an asynchronous request, your raw object’s
+      `configuration_state` becomes `IN_DEPLOYMENT`. While a raw object is
+      `IN_DEPLOYMENT`, you cannot edit its fields, list layouts, or indexes. If
+      your raw object deployment request has not yet begun execution, you can
+      [cancel](https://developer.veevavault.com/api/25.1/#Cancel_HVO) the
+      deployment.
+
+
+      If you don't need to use the [asynchronous
+      request](https://developer.veevavault.com/api/25.1/#Execute_MDL_Async), it
+      is best practice to use the [synchronous
+      request](https://developer.veevavault.com/api/25.1/#Execute_MDL).
+  - name: Documents
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Documents
+
+
+
+      Vault is a highly configurable system designed to reflect the business
+      model of documents. Each Vault can have different document types, document
+      fields, etc. The Document Metadata APIs allow you to query the Vault to
+      understand what document-based metadata is available to use. Learn about
+      <a href="https://platform.veevavault.help/en/lr/21581">Documents &
+      Binders</a> in Vault Help.
+
+
+      **Note:** Because Vault completely indexes the document content and
+      metadata, there is a delay before a new document becomes fully available.
+
+  - name: Documents > Retrieve Document Fields
+    description: |+
+      https://developer.veevavault.com/api/25.1/#Retrieve_Document_Fields
+
+  - name: Documents > Retrieve Document Types
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Retrieve_Document_Types
+
+
+
+      Document type refers both to the structure of hierarchical fields (Type >
+      Subtype > Classification) that determines the relevant document fields,
+      rendition types, and other settings for a document, and to the highest
+      level in that hierarchy. Learn about <a
+      href="https://platform.veevavault.help/en/lr/618">Configuring Document
+      Types</a> in Vault Help.
+
+  - name: Documents > Retrieve Documents
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Retrieve_Documents
+
+
+
+      The following rules govern document retrieval:
+
+
+      * Vault only returns documents to which the logged in user has access to,
+      even if more documents exist.
+
+      * Vault only returns the latest version of each document. To return every
+      version of a document, use the `versionscope=all` query parameter.
+
+      * Vault returns a maximum of 200 documents per page. You can lower this
+      number using the `limit` query parameter.
+
+
+      #### Identifying Binders
+
+
+      The document pseudo-field `binder__v` indicates whether the returned
+      document is a document or a binder.
+
+      The value of `true` means it is a binder, `false` or absence of this field
+      means it is a document. If it is a binder, the binder sections are not
+      listed as part of the response and must be determined using the <a
+      href="https://developer.veevavault.com/api/24.3#Retrieve_Binder">Retrieve
+      Binder API</a> with the `depth=all` query parameter.
+
+
+      #### Identifying CrossLink Documents
+
+
+      A document pseudo-field `crosslink__v` indicates whether the returned
+      document is a regular document (`false`) or a CrossLink document (`true`).
+
+  - name: Documents > Create Documents
+    description: |+
+      https://developer.veevavault.com/api/25.1/#Create_Documents
+
+  - name: Documents > Update Documents
+    description: |+
+      https://developer.veevavault.com/api/25.1/#Update_Documents_API
+
+  - name: Documents > Delete Documents
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Delete_Documents_API
+
+
+
+      After deleting documents, the API allows you to retrieve their IDs for up
+      to 30 days. The deleted files themselves are removed from the server and
+      can only be retrieved by Vault Support. Note that you cannot delete
+      checked out documents unless you have the Power Delete permission. Learn
+      more about Power Delete in <a
+      href="https://platform.veevavault.help/en/lr/3292">Vault Help</a>.
+
+  - name: Documents > Document Locks
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Document_Locks
+
+
+
+      A document "lock" is analogous to "checking out a document" but without
+      the file attached in the response for download. To download the document
+      file after locking it, use the <a
+      href="https://developer.veevavault.com/api/24.3#Download_Document_File">Download
+      Document File</a> endpoint.
+
+
+      Learn about <a href="https://platform.veevavault.help/en/lr/162">Document
+      Checkout (Locks)</a> in Vault Help.
+
+  - name: Documents > Document Renditions
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Document_Renditions
+
+
+
+      Learn about <a href="https://platform.veevavault.help/en/lr/1403">Document
+      Renditions</a> in Vault Help.
+
+
+      Note that requests to retrieve renditions might return an
+      `UNEXPECTED_ERROR`. If this occurs, please retry the request after a few
+      seconds.
+
+  - name: Documents > Document Attachments
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Document_Attachments
+
+
+
+      Learn about <a
+      href="https://platform.veevavault.help/en/lr/24287">Document
+      Attachments</a> in Vault Help.
+
+  - name: Documents > Document Annotations
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Document_Annotations
+
+
+
+      Learn about <a href="https://platform.veevavault.help/en/lr/9777">Document
+      Annotations</a> in Vault Help.
+
+  - name: Documents > Document Relationships
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Document_Relationships
+
+
+
+      You cannot create or delete standard relationship types. Examples of
+      standard relationship types include *Based On* and *Original Source*.
+      Learn about Document Relationships in <a
+      href="https://platform.veevavault.help/en/lr/21330">Vault Help</a>.
+
+  - name: Documents > Export Documents
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Export_Documents
+
+
+
+      The Export Documents API allows you to use the document `id` field to
+      export a set of documents to your Vault's <a
+      href="https://developer.veevavault.com/docs/#FTP">file staging server</a>.
+      For example, you could use <a
+      href="https://developer.veevavault.com/vql/#sending-queries">VQL</a> to
+      query the `id` of all documents from 2016 where `type__v` = `Promotional
+      Piece`, then pass the results into the Export Documents API. This starts
+      an asynchronous job whose status you can check with the Retrieve Document
+      Export Results API.
+
+
+      You can export the following artifacts for a given document:
+
+
+      * Source document
+
+      * Renditions
+
+
+      You can export all versions or choose to export only the latest version.
+
+
+      This API does not support the following:
+
+
+      * Fields
+
+      * Attachments
+
+      * Audit trails
+
+      * Related documents
+
+      * Signature Pages
+
+      * Overlays
+
+      * Protected renditions
+
+
+      Note that the maximum number of document versions (source files) you can
+      export per request is 10,000.
+
+  - name: Documents > Document Events
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Document_Events
+
+
+
+      The Document Events are used to track the document and binder distribution
+      events across sub-systems such as iRep, Controlled Copy, Approved Email
+      and Engage.
+
+  - name: Documents > Document Templates
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Vault_Document_Templates
+
+
+
+      Learn about <a href="https://platform.veevavault.help/en/lr/5509">Document
+      Templates</a> in Vault Help.
+
+  - name: Documents > Document Signatures
+    description: |+
+      https://developer.veevavault.com/api/25.1/#Retrieve_Document_Fields
+
+  - name: Binders
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Vault_Retrieve_Binders_API_Reference
+
+
+
+      Binders organize documents, sections, and other binders into a
+      hierarchical structure that is useful for packaging related documents
+      together for easier management or eventual publishing. Binders are a kind
+      of document and many of the Document API calls, such as metadata,
+      retrieving and setting properties, security, etc. can be used directly on
+      a binder and will not be replicated here. All API calls related to files
+      and renditions will not work on a binder object. Binders do have unique
+      APIs that allow for interrogating and manipulating the binder structure.
+
+
+      Learn about <a
+      href="https://platform.veevavault.help/en/lr/21581">Documents &
+      Binders</a> in Vault Help.
+
+  - name: Binders > Retrieve Binders
+    description: |+
+      https://developer.veevavault.com/api/25.1/#Retrieve_Binders
+
+  - name: Binders > Create Binders
+    description: |+
+      https://developer.veevavault.com/api/25.1/#Create_Binders
+
+  - name: Binders > Update Binders
+    description: |+
+      https://developer.veevavault.com/api/25.1/#Update_Binders
+
+
+  - name: Binders > Delete Binders
+    description: |+
+      https://developer.veevavault.com/api/25.1/#Delete_Binders
+
+
+  - name: Binders > Export Binders
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Export_Binders
+
+
+      The Export Binder API allows you to export a zip archive with all
+      documents from a binder, or a subset of those documents.
+
+
+      You can also export different artifacts for the selected documents,
+      including source documents, renditions, versions, and document fields.
+
+
+      Learn about <a
+      href="https://platform.veevavault.help/en/lr/29681">Exporting Binders</a>
+      in Vault Help.
+
+  - name: Binders > Binder Relationships
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Binder_Relationships
+
+
+
+      Learn about <a href="https://platform.veevavault.help/en/lr/21330">Binder
+      Relationships</a> in Vault Help.
+
+  - name: Binders > Binder Sections
+    description: |+
+      https://developer.veevavault.com/api/25.1/#Binder_Sections
+
+  - name: Binders > Binder Documents
+    description: |+
+      https://developer.veevavault.com/api/25.1/#Binder_Documents
+
+  - name: Binders > Binder Templates
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Vault_Binder_Templates
+
+
+
+      Learn about <a href="https://platform.veevavault.help/en/lr/7625">Binder
+      Templates</a> in Vault Help.
+
+  - name: Binders > Binding Rules
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Binding_Rules
+
+
+
+      Learn about <a href="https://platform.veevavault.help/en/lr/5489">Version
+      Binding</a> in Vault Help.
+
+  - name: Vault Objects
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Vault_Objects_API_Reference
+
+
+
+      Each Vault is configured with a set of standard objects (`product__v`,
+      `country__v`, `study__v`, etc.). These vary by application and
+      configuration.
+
+
+      Vault is also configured with a set of system objects (`user__sys`,
+      `person__sys`, `locale__sys`, etc.) These are available for all Vault
+      applications and configurations.
+
+
+      Admins may also create custom objects (`region__c`, `agency__c`,
+      `manufacturer__c`, etc.). Vault limits the total number of custom objects
+      that Admins can create in a single Vault. By default, the limit is 20.
+
+
+      * The API supports retrieval of Vault Objects and their metadata.
+
+      * The API does not support creating or updating Vault Objects. This must
+      be done by Admin in the UI.
+
+
+      Each object can have multiple object records. For example, the
+      `product__v` object may have records for products named `CholeCap`,
+      `Nyaxa`, and `WonderDrug`. All object records are user-defined.
+
+
+      * The API supports retrieval of Vault Object Records and their metadata.
+
+      * The API supports creating, updating, and deleting object records.
+
+
+      Learn about <a href="https://platform.veevavault.help/en/lr/33946">Vault
+      Objects & Fields</a> in Vault Help.
+
+  - name: Vault Objects > Object Types
+    description: >-
+      https://developer.veevavault.com/api/25.1/#Object_Types
+
+
+      Vault Objects can be can be partitioned into Object Types. For example, a
+      Product object may have two different object types: "Pharmaceutic Product"
+      and "Medical Device Product". These object types may share some fields but
+      also have fields only used in each object type. By using object types, two
+      product groups can not only manage data specific to their business but
+      also easily report on products in both groups.
+  - name: Vault Objects > Object Roles
+    description: >-
+      https://developer.veevavault.com/api/25.1/#Object_Roles
+
+
+      Object records can have different roles available to them depending on
+      their type and lifecycles. There are a set of standard roles that ship
+      with Vault: `owner__v`, `viewer__v`, and `editor__v`. In addition, Admins
+      can create custom roles defined per lifecycle. Not all object records will
+      have users and groups assigned to roles. Learn more about roles on object
+      records in <a href="https://platform.veevavault.help/en/lr/36440">Vault
+      Help</a>.
+
+
+      Through the object record role APIs, you can:
+
+      * Retrieve available roles on object records
+
+      * Retrieve who is currently assigned to a role
+
+      * Add additional users and groups to a role
+
+      * Remove users and groups from roles
+
+
+      Note that all user and group information is returned as IDs, so you need
+      to use the Retrieve User or Retrieve Group API to determine the name.
+
+      For roles on documents or binders, see <a
+      href="https://developer.veevavault.com/api/24.3#Vault_Roles_API_Reference">Roles<a>.
+  - name: Vault Objects > Object Record Attachments
+    description: https://developer.veevavault.com/api/25.1/#Object_Record_Attachments
+  - name: Vault Objects > Object Page Layouts
+    description: >-
+      https://developer.veevavault.com/api/25.1/#Page_Layouts
+
+
+      Object page layouts are defined at the object or object-type level and
+      control the information displayed to a user on the object record detail
+      page. Objects that include multiple object types can define a different
+      layout for each type. Learn more about <a
+      href="https://platform.veevavault.help/en/lr/26387">configuring object
+      page layouts in Vault Help</a>.
+
+
+      The page layout APIs consider the authenticated user’s permissions, so
+      fields which are hidden from the authenticated user will not be included
+      in the API response. For example, field-level security, object controls,
+      and other object-level permissions are considered. Record-level
+      permissions such as atomic security are not considered. Layout rules are
+      not applied, but instead have their configurations returned as metadata.
+      Both active and inactive fields are included in the response.
+  - name: Vault Objects > Merge Object Records
+    description: >-
+      Duplicate records in Vault can happen due to migrations, integrations, or
+      day-to-day activities and may be difficult to resolve. Vault provides a
+      solution to duplicate records by allowing you to merge two records
+      together. You can only initiate record merges through the Vault API or the
+      [Vault Java SDK](https://developer.veevavault.com/sdk/#Record_Merges), and
+      you cannot initiate a record merge through the Vault UI.
+
+
+      Your organization may want to create custom [Record Merge Event
+      Handlers](https://developer.veevavault.com/sdk/#Record_Merge_Event_Handlers)
+      with the Vault Java SDK, which can execute custom logic immediately when a
+      record merge begins or after a record merge completes. For example,
+      directly after a merge starts, you can retrieve the field values on the
+      duplicate record. Directly after the merge completes, you can update any
+      desired information from the duplicate record to the main record. This
+      overrides the default merge behavior which does not copy data between the
+      duplicate and main record.
+
+
+      Learn more about [merging records in Vault
+      Help](https://platform.veevavault.help/en/lr/659058).
+  - name: Vault Objects > Attachment Fields
+    description: >-
+      [https://developer.veevavault.com/api/25.1/#Attachment_Fields](https://developer.veevavault.com/api/24.1/#Attachment_Fields)
+
+
+      _Attachment_ fields allow you to attach a file to a field on an object
+      record. The value of an _Attachment_ field is the file handle for the
+      file.
+  - name: Vault Objects > Roll-up Fields
+    description: >-
+      [https://developer.veevavault.com/api/25.1/#Rollup_Fields](https://developer.veevavault.com/api/24.1/#Rollup_Fields)
+
+
+      You can configure up to 25 Roll-up fields on a parent object to calculate
+      the minimum, maximum, count, or sum of source field values on related
+      child records. <a
+      href="https://platform.veevavault.help/en/lr/15057/#roll-up-fields">Learn
+      more about Roll-up field calculation in Vault Help</a>.
+
+
+      Use the following endpoints to start a full recalculation of all Roll-up
+      fields on a specific object or to check the status of a recalculation.
+      This may be helpful in the following scenarios:
+
+      <ul>
+        <li>When you create a new Roll-up field, Vault does not automatically calculate a value for existing parent records.</li> <li>When you upload a large number of records using Record Migration Mode, Vault bypasses automatic roll-up calculations.</li></ul>
+
+      When performing a full recalculation, Vault evaluates all Roll-up fields
+      on an object asynchronously.
+
+
+      Record triggers on parent records do not fire when Roll-up fields are
+      updated.
+  - name: Document & Binder Roles
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Vault_Roles_API_Reference
+
+
+
+      Documents and binders can have different roles available to them depending
+      on their type and lifecycles. There are a set of standard roles that ship
+      with Vault: `owner__v`, `viewer__v`, and `editor__v`. In addition, Admins
+      can create custom roles defined per lifecycle. Learn more about roles in
+      <a href="https://platform.veevavault.help/en/lr/2662">Vault Help</a>.
+
+
+      Through the Role APIs, you can:
+
+
+      * Retrieve available roles on documents and binders
+
+      * Determine who can be assigned to roles
+
+      * Retrieve default users who are assigned automatically within the Vault
+      UI
+
+      * Retrieve who is currently assigned to a role
+
+      * Add additional users and groups to a role
+
+      * Remove users and groups from roles
+
+
+      All responses return user and group IDs. To determine user and group names
+      and other data, use the Retrieve User or Retrieve Group API.
+
+
+      For roles on object records, see <a
+      href="https://developer.veevavault.com/api/24.3#Object_Roles">Object
+      Roles</a>.
+
+  - name: Document & Binder Roles > Document Roles
+    description: >-
+      https://developer.veevavault.com/api/25.1/#Document_Roles
+
+
+
+      Retrieve and manage roles on documents. Learn about document roles in <a
+      href="https://platform.veevavault.help/en/lr/2662">Vault Help</a>.
+  - name: Document & Binder Roles > Binder Roles
+    description: >-
+      https://developer.veevavault.com/api/25.1/#Binder_Roles
+
+
+
+      Retrieve and manage roles on binders. Learn about binder roles in <a
+      href="https://platform.veevavault.help/en/lr/2662">Vault Help</a>.
+  - name: Workflows
+    description: >-
+      [https://developer.veevavault.com/api/25.1/#Object_Workflows](https://developer.veevavault.com/api/25.1/#Object_Workflows)
+
+
+      A workflow is a series of steps configured in Vault to align with specific
+      business processes. The different types of steps offer a flexible way to
+      organize a wide variety of processes for an object record, including
+      assigning tasks to users, sending notifications, updating fields, and
+      changing a record's lifecycle state or sharing settings. Workflow tasks
+      can allow users to enter comments, choose verdicts (approve, deny, etc.),
+      populate fields, or provide eSignatures.
+
+
+      Object workflows are specific to a single lifecycle, meaning that one (1)
+      workflow cannot apply to multiple object lifecycles. A single object
+      record can only be in one (1) workflow at a time. Learn more about [Object
+      Workflows in Vault Help](https://platform.veevavault.help/en/lr/33498/).
+  - name: Workflows > Workflow Tasks
+    description: https://developer.veevavault.com/api/25.1/#Workflow_Tasks
+  - name: Workflows > Bulk Active Workflow Actions
+    description: >-
+      https://developer.veevavault.com/api/25.1/#Bulk_Active_Workflow_Actions
+
+
+      The API allows you to retrieve actions and action details and to execute
+      actions for up to 500 workflows at once. These can be object, document, or
+      legacy workflows.
+  - name: Document Lifecycle & Workflows
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Vault_Lifecycles_API_Reference
+
+
+
+      Document lifecycles are the sequences of states (Draft, In Review, etc.) a
+      document goes through during its life. A lifecycle can be simple (two
+      states requiring users to manually move between states) or very complex
+      (multiple states with different security and workflows that automatically
+      move the document to another state). In Vault, lifecycles simplify the
+      implementation of business logic that traditionally required custom coding
+      or time-consuming manual setup.
+
+
+      Lifecycle states are the ordered states within a lifecycle representing
+      the stages a document transitions through as users create, review,
+      approve, and eventually archive or replace it. A set of business rules
+      applies to each state and defines what happens to the document in that
+      state. Admins define these rules for each lifecycle state and Vault
+      automatically applies them to every document that enters the state.
+
+
+      Learn about <a
+      href="https://platform.veevavault.help/en/lr/52053">Lifecycles & Workflows
+      in Vault Help</a>.
+
+  - name: Document Lifecycle & Workflows > Document User Actions
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Document_Binder_Lifecycle_Actions
+
+
+
+      This API allows you to initiate of the following user action types:
+
+
+      * **Workflow** (legacy): This action starts the specified legacy workflow.
+      Only legacy workflows that are already configured and active for the
+      selected lifecycle are available. To start a document workflow, see <a
+      href="https://developer.veevavault.com/api/24.3#Multi_Document_Workflows">Document
+      Workflows</a>.
+
+      * **State Change**: This action allows the user to manually move a
+      document into a different lifecycle state. Vault enforces entry criteria
+      and entry actions for the state change.
+
+      * **Controlled Copy**: This action is available in QualityDocs Vaults and
+      with the QualityOne application family. It allows the user to generate and
+      distribute a controlled copy.
+
+      * **Create Presentation**: This action is only available in PromoMats and
+      Medcomms. It creates multiple *Multichannel Slide* documents and a
+      *Multichannel Presentation* binder from a single document. This applies to
+      Vaults that are configured for Engage integration or CLM integration.
+
+      * **Create Email Fragment**: This action is only available in PromoMats
+      and MedComms Vaults that are configured for *Approved Email Integration*.
+      It creates an email fragment for a document by applying a master email
+      fragment.
+
+
+      Your Vault may include other user action types, not all of which can be
+      initiated through the Vault API. Learn more about <a
+      href="https://platform.veevavault.help/en/lr/12339#types">document user
+      action types in Vault Help</a>.
+
+
+      The API does not support initiation of user actions requiring eSignatures.
+
+  - name: Document Lifecycle & Workflows > Binder User Actions
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Binder_User_Actions
+
+
+
+      This API allows you to initiate user actions on binders. See <a
+      href="https://developer.veevavault.com/api/25.1/#Document_Binder_Lifecycle_Actions">supported
+      user actions</a>
+
+
+      Your Vault may include other user action types, not all of which can be
+      initiated through the Vault API. Learn more about <a
+      href="https://platform.veevavault.help/en/lr/12339#types">document user
+      action types in Vault Help</a>.
+
+
+      The API does not support initiation of user actions requiring eSignatures.
+
+  - name: Document Lifecycle & Workflows > Lifecycle Role Assignment Rules
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Lifecycle_Role_Assignment_Rules
+
+
+
+      For both standard and custom roles, you can define a subset of users who
+      are allowed in the role and define users that Vault automatically assigns
+      to the role at document creation or when a workflow starts. You can also
+      override the allowed users and default users settings based on standard
+      object-type document fields like Country, Product, Study, etc.
+
+
+      #### Vault Help Resources
+
+
+      * <a href="https://platform.veevavault.help/en/lr/52053">Lifecycles &
+      Workflows</a>
+
+      * <a href="https://platform.veevavault.help/en/lr/6572">Defining Allowed &
+      Default Users for Roles</a>
+
+      * <a href="https://platform.veevavault.help/en/lr/37744">Users &
+      Groups</a>
+
+      * <a href="https://platform.veevavault.help/en/lr/33946">Fields &
+      Objects</a>
+
+
+      Note the following limitations:
+
+
+      * The API can only be used with active lifecycles and roles.
+
+      * The maximum number of roles that can be created or updated per request
+      is 50,000.
+
+      * The lifecycle role default rule cannot be set when creating override
+      rules.
+
+      * A role cannot be assigned more users or groups to default roles than
+      allowed on the role.
+
+      * The default `owner__v` role cannot be edited.
+
+  - name: Document Lifecycle & Workflows > Document Workflows
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Multi_Document_Workflows
+
+
+
+      Document workflows enable users to send a collection of one or more
+      documents for review and approval using a single workflow. The API allows
+      you to retrieve, manage, and initiate document workflows.
+
+
+
+      Learn about <a
+      href="https://platform.veevavault.help/en/lr/52053">Document Workflows</a>
+      in Vault Help.
+
+  - name: Object Lifecycle & Workflows
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Vault_Workflows_API_Reference
+
+
+
+      Object lifecycles are the sequences of states (Draft, In Review, etc.) an
+      object record goes through. A lifecycle can be simple (two states that
+      require users to manually move between them) or very complex (multiple
+      states with different security and workflows that automatically move
+      records from one state to another). In Vault, lifecycles simplify the
+      implementation of business logic that traditionally required custom coding
+      or time-consuming manual setup. A set of business rules applies to each
+      state and defines what happens to object records in that state. Admins
+      define these rules for each lifecycle state and Vault automatically
+      applies them to every object record that enters the state.
+
+
+      Learn about <a
+      href="https://platform.veevavault.help/en/lr/52053">Lifecycles &
+      Workflows</a> in Vault Help.
+
+  - name: Object Lifecycle & Workflows > Object Record User Actions
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Vault_Object_Record_Lifecycle_Actions
+
+
+
+      The API supports retrieval and initiation of user actions on Vault object
+      records.
+
+  - name: Object Lifecycle & Workflows > Multi-Record Workflows
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Multi_Record_Workflows
+
+
+
+      An object workflow is a series of steps configured in Vault to correspond
+      with the specific business processes of your organization. These steps are
+      actions that occur on or in relation to an individual object record or a
+      group of object records on the same object.
+
+
+      Object workflows are specific to an object, meaning that a single workflow
+      cannot apply to multiple objects. A single object record can only be in
+      one workflow at a time.
+
+  - name: Users
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Users
+
+
+
+      Learn about <a href="https://platform.veevavault.help/en/lr/953">Creating
+      & Managing Users</a> and <a
+      href="https://platform.veevavault.help/en/lr/15127">Managing Users Across
+      Vaults</a> in Vault Help.
+
+
+      **Note:** The endpoints in this section create and manage Legacy Users.
+      Beginning in v18.1, Admins create and manage users with
+      <code>user__sys</code> object records. We strongly recommend creating
+      users as object records using the <a
+      href="https://developer.veevavault.com/api/24.3#Create_User_Object_Record">Create
+      Object Records</a> endpoint.
+
+
+      To update Vault Membership for multiple Vaults within the same domain,
+      create cross-domain users, or add users to a domain without assigning
+      Vault membership, use the <a
+      href="https://developer.veevavault.com/api/24.3#Create_User">Create
+      Users</a> endpoint.
+
+
+      Learn about <a
+      href="https://platform.veevavault.help/en/lr/46534">Managing the User &
+      Person Objects</a>  in Vault Help.
+
+  - name: Users > Create Users
+    description: >-
+      https://developer.veevavault.com/api/25.1/#Create_User
+
+
+      **Note:** Beginning in v18.1, Admins create and manage users with
+      <code>user__sys</code> object records. Unless you are creating
+      cross-domain users or adding users to a domain without assigning Vault
+      membership, we strongly recommend using the <a
+      href="https://developer.veevavault.com/api/25.1/#Create_User_Object_Record">Create
+      Object Records</a> endpoint to create new users.
+
+
+      Create new user accounts or add existing users as cross-domain users.
+      Learn more about <a
+      href="https://platform.veevavault.help/en/lr/38996">cross-domain users</a>
+      in Vault Help. Note that users only receive welcome emails if they are
+      assigned to a Vault. For example, a new domain user who does not have any
+      assigned Vaults will not receive a welcome email.
+
+
+      **Suppressing Welcome Emails**: When creating new users, you can prevent
+      Vault from sending welcome emails to a user by setting the
+      `user_needs_to_change_password__v` setting to `false`. This does not work
+      for users with SSO security profiles, but you can work around this
+      limitation by creating the users with a basic security profile and
+      updating them to the SSO security profile with an update action.
+  - name: Users > Update Users
+    description: >-
+      https://developer.veevavault.com/api/25.1/#Update_User
+
+
+      Update information for a user.
+
+
+      **Note:** Beginning in v18.1, Admins create and manage users with
+      <code>user__sys</code> object records. Unless you are updating domain-only
+      users, we strongly recommend using the <a
+      href="https://developer.veevavault.com/api/25.1/#Update_Object_Record">
+      Update Object Records</a> endpoint to update users.
+
+
+      System Admins and Vault Owners can update users in the Vaults where they
+      have administrative access. System Admins who are also Domain Admins have
+      an unrestricted access to users across all Vaults in the domain.
+
+
+      Note that some user fields are not available to update through the API.
+      For example, you cannot update user profile pictures through the API. To
+      find out which fields are available to update, you can <a
+      href="https://developer.veevavault.com/api/25.1/#Retrieve_User_Metadata">Retrieve
+      User Metadata</a> and find all fields marked as `"editable": true`. If a
+      field is missing from this response, it is not editable.
+  - name: SCIM
+    description: >+
+      https://developer.veevavault.com/api/25.1/#SCIM
+
+
+
+      System for Cross-domain Identity Management (<a
+      href="http://www.simplecloud.info/">SCIM</a>) is designed to make managing
+      user identities in cloud-based applications and services easier. The Vault
+      REST API is based on SCIM 2.0.
+
+
+      All SCIM endpoints require a Vault session ID which can be used as Bearer
+      tokens.
+
+  - name: SCIM > Discovery Endpoints
+    description: >+
+      https://developer.veevavault.com/api/25.1/#SCIM_Info
+
+
+
+      Retrieve a JSON that describes the SCIM specification features available
+      on the currently authenticated Vault.
+
+  - name: SCIM > Users
+    description: |+
+      https://developer.veevavault.com/api/25.1/#SCIM_Users
+
+
+      Retrieve all users with SCIM.
+
+  - name: Groups
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Vault_Groups_API_Reference
+
+
+
+      Groups are key to managing user access in Vault. A group is simply a named
+      list of users. By defining groups which reflect the teams and roles in
+      your company, and then assigning those groups to document roles, you can
+      manage document access more easily and efficiently. In Vaults using
+      Dynamic Access Control (DAC) for documents, Vault also automatically
+      creates groups that correspond to one lifecycle role and additional
+      document field criteria. These are called Auto Managed Groups.
+
+
+      Learn about <a
+      href="https://platform.veevavault.help/en/lr/37744">Groups</a> in Vault
+      Help.
+
+  - name: Picklists
+    description: >-
+      [https://developer.veevavault.com/api/25.1/#Vault_Picklists_API_Reference](https://developer.veevavault.com/api/25.1/#Vault_Picklists_API_Reference)
+
+
+      Picklists allow users to select a value for a field from a range of
+      predefined options. A single picklist may contain up to 2,000 options
+      (values). The API supports retrieving picklists and picklist values,
+      creating and deleting picklist values, and updating picklist value labels
+      and names. The API does not support creating, updating, or deleting the
+      picklists themselves; this must be done in the Admin UI.
+
+
+      Learn about [managing picklists
+      ](https://platform.veevavault.help/en/lr/1269) in Vault Help.
+  - name: Expected Document Lists
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Expected_Document_List
+
+
+
+      Expected Document Lists (EDLs) help you to measure the completeness of
+      projects. Learn about <a
+      href="https://platform.veevavault.help/en/lr/32749">EDLs in Vault
+      Help</a>. Note that if your Vault is configured to set milestone values by
+      EDL item, the following EDL endpoints may trigger updates to a document’s
+      milestone fields. Learn about <a
+      href="https://platform.veevavault.help/en/lr/37991#applying_edl_templates_to_milestones">milestones
+      in Vault Help</a>.
+
+  - name: Security Policies
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Security_Policies
+
+
+
+      Vault security policies allow you to create and manage password policies
+      for users. These settings control password requirements, expiration
+      period, reuse policy, security question policy, and delegated
+      authentication via Salesforce.com&trade;. Security policies apply across
+      all Vaults in a multi-Vault domain.
+
+
+      Learn more about <a
+      href="https://platform.veevavault.help/en/lr/1985">security policies in
+      Vault Help</a>.
+
+  - name: Domain Information
+    description: >-
+      [https://developer.veevavault.com/api/25.1/#Domain_Top](https://developer.veevavault.com/api/25.1/#Domain_Top)
+
+
+      The following endpoints allow Admins to retrieve information about the
+      domain of the authenticated Vault and domains accessible to the
+      authenticated user. Learn more about [Vault domains in Vault
+      Help](https://platform.veevavault.help/en/lr/14691/).
+  - name: Configuration Migration
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Config_Migration
+
+
+
+      The following endpoints allow you to export, import, validate, and deploy
+      Vault Packages (VPKs). These packages allow you to migrate configuration
+      changes between two Vaults. Learn more about <a
+      href="https://platform.veevavault.help/en/lr/36919">Configuration
+      Migration in Vault Help</a>.
+
+  - name: Sandbox Vaults
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Sandboxes
+
+
+
+      Sandbox Vaults provide environments for testing, including development,
+      UAT, and validation testing. Learn more about <a
+      href="https://platform.veevavault.help/en/lr/48988">sandbox Vaults in
+      Vault Help</a>.
+
+  - name: Sandbox Vaults > Pre-Production Vaults
+    description: >-
+      https://developer.veevavault.com/api/25.1/#PreProduction
+
+
+      Pre-production Vaults allow your organization to fully manage a Vault's
+      lifecycle from initial to go-live. When ready, Vault Admins can promote
+      the pre-production Vault to a production Vault through the Admin UI or
+      API. Learn more about <a
+      href="https://platform.veevavault.help/en/lr/70199">pre-production Vaults
+      in Vault Help</a>.
+  - name: Sandbox Vaults > Sandbox Snapshots
+    description: >-
+      Snapshots allow your organization to store configuration and data of
+      sandbox Vaults at a given point in time. You can use snapshots to create
+      and refresh sandbox Vaults. Learn more about [administering sandbox
+      snapshots in Vault
+      Help](https://platform.veevavault.help/en/lr/535936/#create).
+  - name: Logs
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Audit_Logs
+
+
+
+      Vault provides several APIs to track actions performed in the system. The
+      Audit APIs retrieve information about audits and audit types. Use the
+      Audit History APIs to retrieve the audit history for specific document or
+      object records. Download Daily API Usage retrieves the API Usage Logs for
+      a specified date.
+
+
+      **Note:** Audit logs support a precision to one second. Events occurring
+      within a single second may appear in an unexpected order.
+
+
+  - name: Logs > Audit
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Audit_Trails_API_Reference
+
+
+
+      Vault provides robust audit trail and audit logs of all actions performed
+      in the system. These include actions on the documents, objects, the
+      system, logins, and domain levels.
+
+
+      Through the Audit APIs, you can:
+
+
+      * Retrieve audit types you have access to
+
+      * Retrieve all fields and their metadata for a specific audit type
+
+      * Retrieve all records in the specified audit type
+
+
+      Learn about <a href="https://platform.veevavault.help/en/lr/517">Audit
+      Trails</a> & <a href="https://platform.veevavault.help/en/lr/14341">Audit
+      Logs in Vault Help</a>.
+
+  - name: Logs > Audit History
+    description: >+
+      https://developer.veevavault.com/api/25.1/#All_Time_Audit_History
+
+
+
+      With this API, you can retrieve the complete audit history of all actions
+      performed for a specified document or object record. For other audit
+      histories, see <a
+      href="https://developer.veevavault.com/api/24.3#Retrieve_Audit_Details">Retrieve
+      Audit Details</a>.
+
+  - name: Logs > SDK Debug Log
+  - name: Logs > SDK Request Profiler
+    description: >-
+      The _Profiler Log_ allows developers to create SDK request profiling
+      sessions, which allow developers to troubleshoot and improve custom SDK
+      code quality by analyzing results at the SDK request level. The _Profiler
+      Log_ is also available in the Vault UI from **Admin > Logs > Vault Java
+      SDK Logs**. Learn more about the [Profiler Log in Vault
+      Help](https://platform.veevavault.help/en/lr/14341/#profiler-log).
+
+
+      The authenticated user must have the _Admin: Logs: Vault Java SDK_
+      permission to perform CRUD operations on profiling sessions.
+  - name: File Staging
+    description: >+
+      https://developer.veevavault.com/api/25.1/#File_Staging
+
+
+
+      The following endpoints allow you to create and manage files and folders
+      in your Vault's file staging server. Learn more about the <a
+      href="https://platform.veevavault.help/en/lr/38653">file staging server in
+      Vault Help</a>. To upload files larger than 50MB, see <a
+      href="https://developer.veevavault.com/api/24.3#Resumable_Upload_Sessions">Resumable
+      Upload Sessions</a>. You must have the *Application: File Staging:
+      Access*  permission to use the File Staging API.
+
+  - name: File Staging > Resumable Upload Sessions
+    description: >-
+      https://developer.veevavault.com/api/25.1/#Resumable_Upload_Sessions
+
+
+      Use resumable upload sessions to upload files larger than 50MB to the file
+      staging server in three steps:
+
+
+      1. **Create Resumable Upload Session**: Generate an `upload_session_id`,
+      which you can use to upload file parts, resume an interrupted session,
+      retrieve information about a session, and, if necessary, abort a session.
+
+      1. **Upload File Parts**: Use the `upload_session_id` from step 1 to
+      upload parts of a file to an upload session. File parts can be from 5-50MB
+      by default, although limits for your Vault may vary.
+
+      3. **Commit Upload Session**: After you upload all file parts, use this
+      endpoint to end the session and make the completed, reassembled file
+      available in the file staging server.
+
+
+      Use the additional helper endpoints in this section to manage upload
+      sessions. Each Vault allows up to 50 active upload sessions at a time. By
+      default, upload sessions remain active for 72 hours after creation. If a
+      session expires before it is committed, Vault will auto-purge all parts of
+      the upload.
+  - name: Vault Loader
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Vault_Loader
+
+
+
+      The following endpoints allow you to leverage Loader Services to load a
+      set of data objects to your Vault or extract one or more data files from
+      your Vault. Learn more about <a
+      href="https://platform.veevavault.help/en/lr/26597">Vault Loader in Vault
+      Help</a>
+
+
+      **Note:** To take advantage of functionality available in later versions,
+      the Vault Loader API uses Vault Loader v21.3 or later:
+
+      <ul>
+        <li>With API v21.3 and earlier, Vault Loader passes v21.3 through to underlying APIs. For example, a request to Vault Loader API v21.2 will use the v21.3 Vault Objects, Documents, and VQL APIs.</li>
+        <li>With API v22.1+, Vault Loader passes the API request version through to underlying APIs. For example, a request to Vault Loader API v22.2 will use the v22.2 Vault Objects, Documents, and VQL APIs as specified.</li>
+      </ul>
+
+
+  - name: Vault Loader > Multi-File Extract
+    description: |+
+      https://developer.veevavault.com/api/25.1/#Loader_File_Extract
+
+  - name: Vault Loader > Multi-File Load
+    description: |+
+      https://developer.veevavault.com/api/25.1/#Multi_File_Load
+
+  - name: Bulk Translation
+    description: "[https://developer.veevavault.com/api/25.1/#Bulk_Translation](https://developer.veevavault.com/api/25.1/#Bulk_Translation)\n\nThe Bulk Translation API allows you to translate messages in your Vault in bulk. These APIs allow you to quickly compile a list of messages for translation. The exported bulk translation file is editable in Excel, any text editor, or translation software. Learn more about\_[bulk translation in Vault Help](https://platform.veevavault.help/en/lr/13309/#about-bulk-translation).\n\nThere are four (4) types of message translation files:\n\n- Field Labels\n    \n- System Messages\n    \n- Notification Templates\n    \n- User Account Emails\n    \n\nYou must have the\__Admin: Language: Edit_\_permission to use these endpoints."
+  - name: Jobs
+    description: |+
+      https://developer.veevavault.com/api/25.1/#Jobs
+
+
+  - name: Managing Vault Java SDK
+    description: >+
+      https://developer.veevavault.com/api/25.1/#Vault_Java_SDK
+
+
+
+      After you’ve deployed Vault Java SDK code, you may need to perform actions
+      on your code besides additional deployment with a VPK. For example, you
+      may need to download source code or disable a single file.
+
+
+      You also may need to delete a single file rather than all files. However,
+      we do not recommend using the following methods to deploy code as you may
+      introduce or delete code which breaks existing deployed code. For best
+      practices, use the <a
+      href="https://developer.veevavault.com/sdk/#Deploy">VPK Deploy method</a>.
+
+  - name: Managing Vault Java SDK > Queues
+    description: >-
+      https://developer.veevavault.com/api/25.1/#Queues
+
+
+      Vault Spark is a message queue system that enables applications to send
+      and receive messages to and from durable queues using a First-in,
+      First-Out (FIFO) method.
+
+
+      The following endpoints allow you to manage queues for <a
+      href="https://developer.veevavault.com/sdk/#Vault_Integrations">Spark
+      Messaging</a> and SDK job queues.
+
+
+      The current user must have the relevant *Admin: Spark Queues* or *Admin:
+      SDK Job Queues* to perform actions on each queue type. For example, if the
+      API user does not have access to SDK job queues, **Retrieve All Queues**
+      only returns available Spark messaging queues.
+  - name: Custom Pages
+    description: "[https://developer.veevavault.com/api/25.1/#Custom_Pages](https://developer.veevavault.com/api/25.1/#Custom_Pages)\n\nThe Custom Pages APIs allow you to manage the client code for Custom Pages using a client code distribution. The client code distribution contains:\n\n- The client code that defines how Custom Pages display in the Vault UI\n    \n- Metadata that describes the distribution. This metadata must be placed in a manifest file (\\`distribution-manifest.json\\`) in the distribution's root directory.\n    \n\nClient code distributions are [uploaded](https://developer.veevavault.com/api/25.1/#Add_Replace_Single_Distribution) to and downloaded from Vault as a ZIP file. Learn more about [creating a client code distribution for Custom Pages](https://developer.veevavault.com/custompages/).\n\nWhen creating Custom Pages, you can also use the Vault REST API to:\n\n- Create a \\`Page\\` component using [MDL](https://developer.veevavault.com/api/24.3/#Execute_MDL). Learn more in the [Custom Pages documentation](https://developer.veevavault.com/custompages/).\_\n    \n- [Upload and deploy Vault Java SDK server code to Vault](https://developer.veevavault.com/api/24.3/#Add_Code). However, we do not recommend using the Vault REST API to deploy server code. Learn more about the [recommended way to deploy Custom Pages server code to Vault](https://developer.veevavault.com/custompages/#Developing_Server_Code)."
+paths:
+  /api/{version}/delegation/vaults:
+    get:
+      tags:
+        - Authentication > Delegated Access
+      summary: Retrieve Delegations
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Delegations
+
+
+
+        Retrieve Vaults where the currently authenticated user has delegate
+        access. You can then use this information to <a
+        href="https://developer.veevavault.com/api/24.3#Initiate_Delegated_Session">Initiate
+        a Delegated Session</a>.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/delegation/login:
+    post:
+      tags:
+        - Authentication > Delegated Access
+      summary: Initiate Delegated Session
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Initiate_Delegated_Session
+
+
+
+        Generate a delegated session ID. This allows you to call the Vault REST
+        API on behalf of a user who granted you delegate access. To find which
+        users have granted you delegate access, <a
+        href="https://developer.veevavault.com/api/24.3#Retrieve_Delegations">Retrieve
+        Delegations</a>.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          description: >-
+            The sessionId of the currently authenticated user who will initiate
+            the delegated session. Cannot be a delegated_sessionid.
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/auth:
+    post:
+      tags:
+        - Authentication
+      summary: User Name and Password
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Basic_Auth
+
+
+        Authenticate your account using your Vault user name and password to
+        obtain Vault Session ID. Vault limits the number of Authentication API
+        calls based on the user name and the domain name used in the API call.
+        To determine the Vault Authentication API burst limit for your Vault or
+        the length of delay for a throttled response, check the <a
+        href="https://developer.veevavault.com/docs/#Auth_API_Rate_Limit_Headers">response
+        headers</a> or the <a
+        href="https://platform.veevavault.help/en/lr/14341#API_Usage_Logs">API
+        Usage Logs</a>.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /auth/oauth/session/:{oath_oidc_profile_id}:
+    post:
+      tags:
+        - Authentication
+      summary: OAuth 2.0 / OpenID Connect
+      description: >-
+        https://developer.veevavault.com/api/25.1/#OAuth2_OIDC_Auth
+
+
+        Authenticate your account using OAuth 2.0 / Open ID Connect token to
+        obtain a Vault Session ID. Learn more about <a
+        href="https://platform.veevavault.help/en/lr/43329">OAuth 2.0 / Open ID
+        Connect in Vault Help</a>.
+
+
+        When requesting a `sessionId`, Vault allows the ability for Oauth2/OIDC
+        client applications to pass the `client_id` with the request. Vault uses
+        this `client_id` when talking with the introspection endpoint at the
+        authorization server to validate that the `access_token` presented by
+        the application is valid. Learn more about <a
+        href="https://developer.veevavault.com/docs/#Client_ID">Client ID in the
+        REST API Documentation</a>.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: Bearer {{access_token}}
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: oath_oidc_profile_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/:
+    get:
+      tags:
+        - Authentication
+      summary: Retrieve API Versions
+      description: |-
+        https://developer.veevavault.com/api/25.1/#Retrieve_Versions
+
+        Retrieve all supported versions of the Vault REST API.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /auth/discovery:
+    post:
+      tags:
+        - Authentication
+      summary: Authentication Type Discovery
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Discovery
+
+
+        Discover the authentication type of a user. With this API, applications
+        can dynamically adjust the login requirements per user, and support
+        either username/password or OAuth2.0 / OpenID Connect authentication
+        schemes.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/keep-alive:
+    post:
+      tags:
+        - Authentication
+      summary: Session Keep Alive
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Keep_Alive
+
+
+        Given an active `sessionId`, keep the session active by refreshing the
+        session duration.
+
+
+        A Vault session is considered active as long as some activity (either
+        through the UI or API) happens within the maximum inactive session
+        duration. This maximum inactive session duration varies by Vault and is
+        configured by your Vault Admin. The maximum active session duration is
+        48 hours, which is not configurable. Learn more about <a
+        href="https://developer.veevavault.com/docs/#Session_Mangement">best
+        practices for session management</a>.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/users/me:
+    get:
+      tags:
+        - Authentication
+      summary: Validate Session User
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Validate_Session
+
+
+        Given a valid session ID, this request returns information for the
+        currently authenticated user. If the session ID is not valid, this
+        request returns an `INVALID_SESSION_ID` error `type`. This is similar to
+        a <a href="https://en.wikipedia.org/wiki/Whoami)">`whoami` request</a>.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: exclude_vault_membership
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Set to true to omit vault_membership fields. If you don’t
+            need these fields, this may increase performance. If omitted,
+            vault_membership fields are included in the response.
+        - name: exclude_app_licensing
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Set to true to omit app_licensing fields. If you don’t
+            need these fields, this may increase performance. If omitted,
+            app_licensing fields are included in the response.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - Users > Update Users
+      summary: Update My User
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Update_My_User
+
+
+        Update information for the currently authenticated user.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/session:
+    delete:
+      tags:
+        - Authentication
+      summary: End Session
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#End_Session](https://developer.veevavault.com/api/25.1/#End_Session)
+
+
+        Given an active `sessionId`, inactivate an API session. If a user has
+        multiple active sessions, inactivating one session does not inactivate
+        all sessions for that user. Each session has its own unique `sessionId`.
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          description: The Vault sessionId to end.
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/directdata/files:
+    get:
+      tags:
+        - Direct Data
+      summary: Retrieve Available Direct Data Files
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Retrieve_Available_Direct_Data_Files](https://developer.veevavault.com/api/25.1/#Retrieve_Available_Direct_Data_Files)
+
+
+        **Retrieve a list of all Direct Data files available for download.**
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: extract_type
+          in: query
+          schema:
+            type: string
+          description: >-
+            The Direct Data file type: incremental_directdata, full_directdata,
+            or log_directdata. If omitted, returns all files.
+          example: incremental_directdata
+        - name: start_time
+          in: query
+          schema:
+            type: string
+          description: >-
+            Specify a time in YYYY-MM-DDTHH:MM:SSZ format. For example, 7AM on
+            January 15, 2024 would use 2024-01-15T07:00:00Z. If omitted,
+            defaults to the Vault’s creation date and time.
+          example: 2023-12-07T00:00Z
+        - name: stop_time
+          in: query
+          schema:
+            type: string
+          description: >-
+            Specify a time in YYYY-MM-DDTHH:MM:SSZ format. For example, 9AM on
+            January 15, 2024 would use 2024-01-15T09:00:00Z. If omitted,
+            defaults to today’s date and current time.
+          example: 2023-12-08T00:00Z
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/directdata/files/:{name}:
+    get:
+      tags:
+        - Direct Data
+      summary: Download Direct Data File
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Download_a_Direct_Data_File](https://developer.veevavault.com/api/25.1/#Download_a_Direct_Data_File)
+
+
+        Download a Direct Data file.
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/query:
+    post:
+      tags:
+        - Vault Query Language (VQL)
+      summary: Submitting a Query
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Submit_Query
+
+
+        Retrieve and filter Vault data using a VQL query.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-DescribeQuery
+          in: header
+          schema:
+            type: boolean
+          example: 'true'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/query/{next_page}:
+    post:
+      tags:
+        - Vault Query Language (VQL)
+      summary: Next Page URL
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Submit_Query
+
+
+        Retrieve the next page of results after submitting a query.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-DescribeQuery
+          in: header
+          schema:
+            type: boolean
+          example: 'true'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: next_page
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/query/{previous_page}:
+    post:
+      tags:
+        - Vault Query Language (VQL)
+      summary: Previous Page URL
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Submit_Query
+
+
+        Retrieve the previous page of results after submitting a query.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-DescribeQuery
+          in: header
+          schema:
+            type: boolean
+          example: 'true'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: previous_page
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/configuration/:{component_type}:
+    get:
+      tags:
+        - Metadata Definition Language (MDL) > Retrieve Component Records
+      summary: Retrieve Component Record Collection
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Component_Record_Collection
+
+
+
+        Retrieve all records for a specific component type.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: component_type
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/configuration/:{component_type_and_record_name}:
+    get:
+      tags:
+        - Metadata Definition Language (MDL) > Retrieve Component Records
+      summary: Retrieve Component Record (XML/JSON)
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Component_Record
+
+
+
+        Retrieve metadata of a specific component record as JSON or XML. To
+        retrieve as MDL, see <a
+        href="https://developer.veevavault.com/api/24.3#Retrieve_Component_Record_MDL">Retrieve
+        Component Record MDL</a>. Not all component types are eligible for
+        record description retrieval. For details, see the Describe column in
+        the <a
+        href="https://developer.veevavault.com/mdl/#component-support-matrix">Component
+        Support Matrix</a>.
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: loc
+          in: query
+          schema:
+            type: string
+          description: >-
+            When localized (translated) strings are available, retrieve them by
+            setting loc to true.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: component_type_and_record_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/mdl/components/:{component_type_and_record_name}:
+    get:
+      tags:
+        - Metadata Definition Language (MDL) > Retrieve Component Records
+      summary: Retrieve Component Record (MDL)
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Component_Record_MDL
+
+
+
+        Retrieve metadata of a specific component record as MDL. To retrieve as
+        JSON or XML, see <a
+        href="https://developer.veevavault.com/api/24.3#Retrieve_Component_Record">Retrieve
+        Component Record</a>. Vault does not generate RECREATE statements for
+        all component types. For details, see the Generate RECREATE column in
+        the <a
+        href="https://developer.veevavault.com/mdl/#component-support-matrix">Component
+        Support Matrix</a>.
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: component_type_and_record_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/mdl/files:
+    post:
+      tags:
+        - Metadata Definition Language (MDL) > Components with Content
+      summary: Upload Content File
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Upload_File
+
+
+
+        This endpoint allows you to upload a content file to be referenced by a
+        component.
+
+
+        Once uploaded, Vault stores the file in a generic files staging area
+        where they will remain until referenced by a component. Once referenced,
+        Vault cannot access the named file from the staging area.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: multipart/form-data
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/mdl/components/:{component_type_and_record_name}/files:
+    get:
+      tags:
+        - Metadata Definition Language (MDL) > Components with Content
+      summary: Retrieve Content File
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Content_File
+
+
+        Retrieve the content file of a specified component.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: component_type_and_record_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/mdl/execute_async:
+    post:
+      tags:
+        - Metadata Definition Language (MDL) > Asynchronous MDL Requests
+      summary: Execute MDL Script Asynchronously
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Execute_MDL_Async
+
+
+        This asynchronous endpoint executes the given MDL script on a Vault.
+
+
+        While you can execute any MDL script with this endpoint, it is required
+        if you’re operating on 10,000+ `raw` object records and executing one of
+        the following operations:
+
+
+        * Enabling lifecycles
+
+        * Enabling or disabling object types
+
+        * Adding or removing a field
+
+        * Updating the max length of any variable-length field, such as *Text*,
+        *Long Text*, or *Rich Text*
+
+        * Adding or removing an `Index`
+
+        * Changing the fields that compose an `Index` or otherwise would cause
+        reindexing to occur
+
+
+        After initiating this request, your raw object’s `configuration_state`
+        becomes `IN_DEPLOYMENT`. While a raw object is `IN_DEPLOYMENT`, you
+        cannot edit its fields, list layouts, or indexes. If your raw object
+        deployment request has not yet begun execution, you can <a
+        href="https://developer.veevavault.com/api/25.1/#Cancel_HVO">cancel</a>
+        the deployment.
+
+
+        This endpoint can only queue one asynchronous change at a time. If you
+        have multiple requests, you must wait for the previous request to
+        complete or use a VPK.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example: ''
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/mdl/execute_async/:job_id/results:
+    get:
+      tags:
+        - Metadata Definition Language (MDL) > Asynchronous MDL Requests
+      summary: Retrieve Asynchronous MDL Script Results
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Retrieve_MDL_Results
+
+
+        After submitting a request to deploy an MDL script asynchronously, you
+        can query Vault to determine the results of the request.
+
+
+        Before submitting this request:
+
+
+        * You must have previously requested a submission export job (via the
+        API) which is no longer active.
+
+        * You must have a valid `job_id` field value returned from the <a
+        href="https://developer.veevavault.com/api/25.1/#Execute_MDL_Async">Execute
+        MDL Script Asynchronously</a> request.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/vobjects/:object_name/actions/canceldeployment:
+    post:
+      tags:
+        - Metadata Definition Language (MDL) > Asynchronous MDL Requests
+      summary: Cancel Raw Object Deployment
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Cancel_HVO
+
+
+        Cancel a deployment of configuration changes to a raw object. To use
+        this endpoint, your raw object's `configuration_state` must be
+        `IN_DEPLOYMENT`.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example: ''
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/mdl/execute:
+    post:
+      tags:
+        - Metadata Definition Language (MDL)
+      summary: Execute MDL Script
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Execute_MDL
+
+
+        This synchronous endpoint executes the given MDL script on a Vault. Note
+        that some large operations require use of the <a
+        href="https://developer.veevavault.com/api/25.1/#Execute_MDL_Async">asynchronous
+        endpoint</a>.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example: ''
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/components:
+    get:
+      tags:
+        - Metadata Definition Language (MDL)
+      summary: Retrieve All Component Metadata
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Retrieve_All_Component_Metadata
+
+
+        Retrieve metadata of all component types in your Vault.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/components/:{component_type}:
+    get:
+      tags:
+        - Metadata Definition Language (MDL)
+      summary: Retrieve Component Type Metadata
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Retrieve_Component_Type_Metadata
+
+
+        Retrieve metadata of a specific component type.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: component_type
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/objects/documents/properties:
+    get:
+      tags:
+        - Documents > Retrieve Document Fields
+      summary: Retrieve All Document Fields
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Retrieve_All_Document_Fields
+
+
+        Retrieve all standard and custom document fields and field properties.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/objects/documents/properties/find_common:
+    post:
+      tags:
+        - Documents > Retrieve Document Fields
+      summary: Retrieve Common Document Fields
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Common_Document_Fields
+
+
+
+        Retrieve all document fields and field properties which are common to
+        (shared by) a specified set of documents. This allows you to determine
+        which document fields are eligible for bulk update.
+
+
+        Learn about <a href="https://platform.veevavault.help/en/lr/4884">Shared
+        Fields</a> in Vault Help.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/objects/documents/types:
+    get:
+      tags:
+        - Documents > Retrieve Document Types
+      summary: Retrieve All Document Types
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_All_Document_Types
+
+
+
+        Retrieve all document types. These are the top-level of the document
+        type/subtype/classification hierarchy.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/objects/documents/types/:{type}:
+    get:
+      tags:
+        - Documents > Retrieve Document Types
+      summary: Retrieve Document Type
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Type
+
+
+
+        Retrieve all metadata from a document type, including all of its
+        subtypes (when available).
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: type
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/objects/documents/types/:{type}/subtypes/:{subtype}:
+    get:
+      tags:
+        - Documents > Retrieve Document Types
+      summary: Retrieve Document Subtype
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Subtype
+
+
+
+        Retrieve all metadata from a document subtype, including all of its
+        classifications (when available).
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: type
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: subtype
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/objects/documents/types/:{type}/subtypes/:{subtype}/classifications/:{classification}:
+    get:
+      tags:
+        - Documents > Retrieve Document Types
+      summary: Retrieve Document Classification
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Classification
+
+
+
+        Retrieve all metadata from a document classification.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: type
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: subtype
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: classification
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents:
+    get:
+      tags:
+        - Binders > Retrieve Binders
+      summary: Retrieve All Binders
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_All_Binders
+
+
+
+        In Vault, binders are just another kind of document. Therefore, to
+        retrieve a list of all binders in your Vault, you must use the same API
+        endpoint to retrieve documents. By searching the response, you can
+        distinguish binders from documents by using the document field
+        `binder__v` set to `true` or `false`. See the response details below.
+        Note that nested binders (a binder contained within another binder) are
+        not retrieved.
+
+
+        This endpoint does not retrieve binder sections, which means the
+        response will not include binders within other binder sections. To
+        retrieve all metadata configured on a binder, including sections, you
+        must use the binder IDs retrieved from this request in the <a
+        href="https://developer.veevavault.com/api/24.3#Retrieve_Binder">Retrieve
+        Binder</a> endpoint.
+
+
+        Alternatively, you can use VQL to find just binders `SELECT id FROM
+        binders`. See <a
+        href="https://developer.veevavault.com/vql/#Query_Syntax_Structure">VQL
+        documentation</a> for details.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Documents > Create Documents
+      summary: Create Single Document
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Create_Single_Document
+
+
+
+        **Note:** If you need to create more than one document, it is best
+        practice to use the <a
+        href="https://developer.veevavault.com/api/25.1/#Bulk_Create_Documents">bulk
+        API</a>.
+
+
+        Create a single document.
+
+
+        The API supports all security settings except document lifecycle role
+        defaults. You must create documents through the UI if your documents
+        require document lifecycle role defaults. Learn more about <a
+        href="https://platform.veevavault.help/en/gr/6572/">document lifecycle
+        role defaults in Vault Help</a>.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-MigrationMode
+          in: header
+          schema:
+            type: boolean
+          description: >-
+            When set to true,  you can use the status__v field to create
+            documents in any lifecycle state. Additionally, you can manually set
+            the name, document number, and version number. Vault also bypasses
+            entry criteria, entry actions, and event actions. You must have the
+            Document Migration permission to use this header. Learn more about
+            <a href="https://platform.veevavault.help/en/gr/54028">Document
+            Migration Mode in Vault Help.</a>
+          example: 'true'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}:
+    get:
+      tags:
+        - Documents > Document Attachments
+      summary: Determine if a Document has Attachments
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Determine_if_a_Document_has_Attachments
+
+
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - Documents > Update Documents
+      summary: Reclassify Single Document
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Reclassify_Document](https://developer.veevavault.com/api/25.1/#Reclassify_Document)
+
+
+        Reclassify allows you to change the document type of an existing
+        document or assign a document type to an unclassified document. This
+        endpoint is analogous to the _Reclassify_ action in the Vault UI.
+
+
+        A document "type" is the combination of the `type__v`, `subtype__v`, and
+        `classification__v` fields on a document. When you reclassify, Vault may
+        add or remove certain fields on the document. Add these new fields and
+        values to the body of this request. If a new required field is missing,
+        the error response will list the name of the required field. The API
+        does not currently support bulk reclassify.
+
+
+        Not all documents are eligible for reclassification. For example, you
+        can only reclassify the latest version of a document and you cannot
+        reclassify a checked out document. To reclassify more than one document,
+        use the [Reclassify Multiple
+        Documents](https://developer.veevavault.com/api/25.1/#Reclassify_Multiple_Documents)
+        endpoint.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-MigrationMode
+          in: header
+          schema:
+            type: boolean
+          description: >-
+            When set to true, Vault allows you to manually set the document
+            number and to update documents to any lifecycle state using the
+            status__v field. All other Document Migration Mode overrides
+            available at document creation are ignored, but do not generate an
+            error message.  You must have the Document Migration permission to
+            use this header. Learn more about <a
+            href="https://platform.veevavault.help/en/gr/54028">Document
+            Migration Mode in Vault Help.</a>
+          example: 'true'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Documents > Update Documents
+      summary: Create Single Document Version
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Create_Document_Version](https://developer.veevavault.com/api/25.1/#Create_Document_Version)
+
+
+        **Note:** If you need to create more than one document version, it is
+        best practice to use the
+
+
+        <a
+        href="https://developer.veevavault.com/api/25.1/#Create_Document_Versions_Bulk">bulk
+        API</a>
+
+
+        .
+
+
+        Add a new draft version of an existing document. You can choose to
+        either use the existing source file or a new source file. These actions
+        increase the target document’s minor version number. This is analogous
+        to using the _Create Draft_ action in the UI.
+
+
+        Note that not all documents are eligible for draft creation. For
+        example, you cannot create a draft of a checked out document. Learn more
+        about
+
+
+        <a
+        href="https://platform.veevavault.help/en/lr/1560#Eligible_Documents">creating
+        new draft versions in Vault Help</a>
+
+
+        .
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: multipart/form-data
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: suppressRendition
+          in: query
+          schema:
+            type: string
+          description: >-
+            Set to true to suppress automatic generation of the viewable
+            rendition. If omitted, defaults to false
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Documents > Delete Documents
+      summary: Delete Single Document
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Delete_Document
+
+
+
+        **Note:** If you need to delete more than one document, it is best
+        practice to use the <a
+        href="https://developer.veevavault.com/api/25.1/#Delete_Documents">bulk
+        API</a>.
+
+
+        Delete all versions of a document, including all source files and
+        viewable renditions.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/versions:
+    get:
+      tags:
+        - Documents > Retrieve Documents
+      summary: Retrieve Document Versions
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Versions
+
+
+        Retrieve all versions of a document.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}:
+    get:
+      tags:
+        - Documents > Retrieve Documents
+      summary: Retrieve Document Version
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Version
+
+
+        Retrieve all fields and values configured on a document version.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - Documents > Update Documents
+      summary: Update Document Version
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Update_Document_Version
+
+
+
+        Update editable field values on a specific version of a document. See
+        also <a
+        href="https://developer.veevavault.com/api/24.3#Update_Document">Update
+        Document</a> above.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-MigrationMode
+          in: header
+          schema:
+            type: boolean
+          description: >-
+            When set to true, Vault allows you to manually set the document
+            number. All other Document Migration Mode overrides available at
+            document creation are ignored, but do not generate an error message.
+            You must have the Document Migration permission to use this header.
+            Learn more about <a
+            href="https://platform.veevavault.help/en/gr/54028">Document
+            Migration Mode in Vault Help.</a>
+          example: 'true'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Documents > Delete Documents
+      summary: Delete Single Document Version
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Delete_Document_Version
+
+
+
+        **Note:** If you need to delete more than one document version, it is
+        best practice to use the <a
+        href="https://developer.veevavault.com/api/25.1/#Delete_Document_Versions">bulk
+        API</a>.
+
+
+        Delete a specific version of a document, including the version's source
+        file and viewable rendition. Other versions of the document remain
+        unchanged. See also <a
+        href="https://developer.veevavault.com/api/24.3#Delete_Document">Delete
+        Document</a>.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: ''
+          in: header
+          schema:
+            type: string
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/file:
+    get:
+      tags:
+        - Documents > Retrieve Documents
+      summary: Download Document File
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Download_Document_File
+
+
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: lockDocument
+          in: query
+          schema:
+            type: boolean
+          description: >-
+            Set to true to Check Out this document before retrieval. If omitted,
+            defaults to false.
+          example: 'false'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/file:
+    get:
+      tags:
+        - Documents > Retrieve Documents
+      summary: Download Document Version File
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Download_Document_Version_File
+
+
+
+        Download the file of a specific document version.
+
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: ''
+          in: query
+          schema:
+            type: string
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/thumbnail:
+    get:
+      tags:
+        - Documents > Retrieve Documents
+      summary: Download Document Version Thumbnail File
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Download_Document_Version_Thumbnail
+
+
+
+        Download the thumbnail image file of a specific document version.
+
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: ''
+          in: query
+          schema:
+            type: string
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/batch:
+    post:
+      tags:
+        - Documents > Create Documents
+      summary: Create Multiple Documents
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Bulk_Create_Documents
+
+
+
+        This endpoint allows you to create multiple documents at once with a CSV
+        input file.
+
+
+        * The maximum CSV input file size is 1GB.
+
+        * The values in the input must be UTF-8 encoded.
+
+        * CSVs must follow the <a href
+        ="https://datatracker.ietf.org/doc/html/rfc4180">standard format.</a>
+
+        * The maximum batch size is 500.
+
+
+        Note that this API does not support adding multi-value relationship
+        fields by name. To add multi-value fields, you must first retrieve the
+        ID values and add them to the relationship field.
+
+
+        The API supports all security settings except document lifecycle role
+        defaults. You must create documents through the UI if your documents
+        require document lifecycle role defaults. Learn more about <a
+        href="https://platform.veevavault.help/en/gr/6572/">document lifecycle
+        role defaults in Vault Help</a>.
+
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-MigrationMode
+          in: header
+          schema:
+            type: boolean
+          description: >-
+            When set to true, Vault allows you to create documents in any
+            lifecycle state using the status__v field, and to manually set the
+            name, document number, and version number. Vault also bypasses entry
+            criteria, entry actions, and event actions. You must have the
+            Document Migration permission to use this header. Learn more about
+            <a href="https://platform.veevavault.help/en/gr/54028">Document
+            Migration Mode in Vault Help.</a>
+          example: 'true'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - Documents > Update Documents
+      summary: Update Multiple Documents
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Update_Documents
+
+
+
+        Bulk update editable field values on multiple documents. You can only
+        update the latest version of each document. To update past document
+        versions, see <a
+        href="https://developer.veevavault.com/api/24.3#Update_Document_Version">Update
+        Document Version</a>.
+
+
+        * The maximum CSV input file size is 1GB.
+
+        * The values in the input must be UTF-8 encoded.
+
+        * CSVs must follow the <a href
+        ="https://datatracker.ietf.org/doc/html/rfc4180">standard format.</a>
+
+        * The maximum batch size is 1,000.
+
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-MigrationMode
+          in: header
+          schema:
+            type: boolean
+          description: >-
+            When set to true, Vault allows you to change the document number.
+            All other Document Migration Mode overrides available at document
+            creation are ignored, but do not generate an error message. You must
+            have the Document Migration permission to use this header.Learn more
+            about <a
+            href="https://platform.veevavault.help/en/gr/54028">Document
+            Migration Mode in Vault Help.</a>
+          example: 'true'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Documents > Delete Documents
+      summary: Delete Multiple Documents
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Delete_Documents
+
+
+
+        Delete all versions of multiple documents, including all source files
+        and viewable renditions.
+
+
+        * The maximum input file size is 1GB.
+
+        * The values in the input must be UTF-8 encoded.
+
+        * CSVs must follow the <a href
+        ="https://datatracker.ietf.org/doc/html/rfc4180">standard format.</a>
+
+        * The maximum batch size is 500.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: idParam
+          in: query
+          schema:
+            type: string
+          description: If you’re identifying documents in your input by their external ID
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/batch/actions/reclassify:
+    put:
+      tags:
+        - Documents > Update Documents
+      summary: Reclassify Multiple Documents
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Reclassify_Multiple_Documents](https://developer.veevavault.com/api/25.1/#Reclassify_Multiple_Documents)
+
+
+        Reclassify allows you to change the document type of an existing
+        document or assign a document type to an unclassified document. This
+        endpoint is analogous to the _Reclassify_ action in the Vault UI.
+
+
+        A document "type" is the combination of the `type__v`, `subtype__v`, and
+        `classification__v` fields on a document. When you reclassify, Vault may
+        add or remove certain fields on the document. Add these new fields and
+        values to the body of this request. If a new required field is missing,
+        the error response will list the name of the required field. The API
+        does not currently support bulk reclassify.
+
+
+        Not all documents are eligible for reclassification. For example, you
+        can only reclassify the latest version of a document and you cannot
+        reclassify a checked out document. Learn more about
+
+
+        <a href="https://platform.veevavault.help/en/lr/2271">reclassifying
+        documents in Vault Help</a>
+
+
+        .
+
+
+        - The maximum CSV input file size is 1GB.
+
+        - The values in the input must be UTF-8 encoded.
+
+        - CSVs must follow the
+            
+            <a href="https://datatracker.ietf.org/doc/html/rfc4180">standard format.</a>
+            
+        - The maximum batch size is 1,000.
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-MigrationMode
+          in: header
+          schema:
+            type: boolean
+          description: >-
+            When set to true, Vault allows you to manually set the document
+            number and to update documents to any lifecycle state using the
+            status__v field. All other Document Migration Mode overrides
+            available at document creation are ignored, but do not generate an
+            error message.  You must have the Document Migration permission to
+            use this header. Learn more about <a
+            href="https://platform.veevavault.help/en/gr/54028">Document
+            Migration Mode in Vault Help.</a>
+          example: 'true'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/versions/batch:
+    post:
+      tags:
+        - Documents > Update Documents
+      summary: Create Multiple Document Versions
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Create_Document_Versions_Bulk
+
+
+
+        Create or add document versions in bulk.
+
+
+        * The maximum CSV input file size is 1GB.
+
+        * The values in the input must be UTF-8 encoded.
+
+        * CSVs must follow the <a href
+        ="https://datatracker.ietf.org/doc/html/rfc4180">standard format.</a>
+
+        * The maximum batch size is 500.
+
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-MigrationMode
+          in: header
+          schema:
+            type: string
+          description: >-
+            Must be set to true. Vault allows you to manually set the name and
+            version number and to create documents in any lifecycle state using
+            the `status__v` field, but does not allow you to change the document
+            number. Vault also bypasses entry criteria, entry actions, and event
+            actions. You must have the Document Migration permission to use this
+            header. Learn more about <a
+            href="https://platform.veevavault.help/en/gr/54028">Document
+            Migration Mode in Vault Help.</a>
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: idParam
+          in: query
+          schema:
+            type: string
+          description: If you’re identifying documents in your input by their external ID
+          example: external_id__v
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Documents > Delete Documents
+      summary: Delete Multiple Document Versions
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Delete_Document_Versions
+
+
+
+        Delete a specific version of multiple documents, including the version's
+        source file and viewable rendition.
+
+
+        * The maximum input file size is 1GB.
+
+        * The values in the input must be UTF-8 encoded.
+
+        * CSVs must follow the <a href
+        ="https://datatracker.ietf.org/doc/html/rfc4180">standard format.</a>
+
+        * The maximum batch size is 500.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: idParam
+          in: query
+          schema:
+            type: string
+          description: If you’re identifying documents in your input by their external ID
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/deletions/documents:
+    get:
+      tags:
+        - Documents > Delete Documents
+      summary: Retrieve Deleted Document IDs
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Deleted_Documents
+
+
+
+        Retrieve IDs of documents deleted within the past 30 days.
+
+
+        After documents and document versions are deleted, their IDs remain
+        available for retrieval for 30 days. After that, they cannot be
+        retrieved. This request supports optional parameters to narrow the
+        results to a specific date and time range within the past 30 days.
+
+
+        To completely restore a document deleted within the last 30 days,
+        contact Veeva support.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: start_date
+          in: query
+          schema:
+            type: string
+          description: >-
+            Specify a date (no more than 30 days past) after which Vault will
+            look for deleted documents. Dates must be YYYY-MM-DDTHH:MM:SSZ
+            format, for example, 7AM on January 15, 2016 would use
+            2016-01-15T07:00:00Z
+        - name: end_date
+          in: query
+          schema:
+            type: string
+          description: >
+            Specify a date (no more than 30 days past) before which Vault will
+            look for deleted documents. Dates must be YYYY-MM-DDTHH:MM:SSZ
+            format, for example, 7AM on January 15, 2016 would use
+            2016-01-15T07:00:00Z
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/objects/documents/lock:
+    get:
+      tags:
+        - Documents > Document Locks
+      summary: Retrieve Document Lock Metadata
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Lock_Metadata
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/lock:
+    post:
+      tags:
+        - Documents > Document Locks
+      summary: Create Document Lock
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Create_Document_Lock
+
+
+
+        A document lock is analogous to checking out a document but without the
+        file attached in the response for download.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    get:
+      tags:
+        - Documents > Document Locks
+      summary: Retrieve Document Lock
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Lock
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Documents > Document Locks
+      summary: Delete Document Lock
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Delete_Document_Lock
+
+
+
+        Deleting a document lock is analogous to undoing check out of a
+        document.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/batch/lock:
+    delete:
+      tags:
+        - Documents > Document Locks
+      summary: Undo Collaborative Authoring Checkout
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Undo_Collaborative_Authoring_Checkout](https://developer.veevavault.com/api/25.1/#Undo_Collaborative_Authoring_Checkout)
+
+
+        Undo Collaborative Authoring checkout on up to 500 documents at once.
+        Learn more about [Collaborative Authoring in Vault
+        Help](https://platform.veevavault.help/en/lr/56842).
+
+
+        To undo basic checkout, see [Delete Document
+        Lock](http://localhost:8400/api/25.1/#Delete_Document_Lock).
+
+
+        Some HTTP clients do not support `DELETE` requests with a body. As a
+        workaround for these cases, you can simulate this request using the
+        `POST` method with the `_method=DELETE` query parameter.
+
+
+        On `SUCCESS`, Vault returns a `responseStatus` and `responseMessage` for
+        each `id` in the request body. Partial success is allowed, meaning some
+        documents in the batch may succeed while others fail. For any failed
+        documents, the response includes a reason for the failure.
+
+
+        **Request**
+
+
+        ``` bash
+
+        $ curl -X POST -H "Authorization: {SESSION_ID}" \
+
+        -H "Content-Type: text/csv" \
+
+        -H "Accept: application/json" \
+
+        --data "id
+
+        7652
+
+        3
+
+        8" \
+
+        https://myvault.veevavault.com/api/v24.2/objects/documents/batch/lock
+
+         ```
+
+        **Response**
+
+
+        ``` json
+
+        {
+           "responseStatus": "SUCCESS",
+           "data": [
+               {
+                   "responseStatus": "EXCEPTION",
+                   "responseMessage": "Document not found 19523/7652",
+                   "id": 7652
+               },
+               {
+                   "responseStatus": "FAILURE",
+                   "responseMessage": "Cannot use office365__sys undo check out for a document checked out to basic__sys",
+                   "id": 3
+               },
+               {
+                   "responseStatus": "SUCCESS",
+                   "responseMessage": "Undo check out successful",
+                   "id": 8
+               }
+           ]
+        }
+
+         ```
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/renditions:
+    get:
+      tags:
+        - Documents > Document Renditions
+      summary: Retrieve Document Renditions
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Renditions
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/renditions:
+    get:
+      tags:
+        - Documents > Document Renditions
+      summary: Retrieve Document Version Renditions
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Version_Renditions
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/renditions/:{rendition_type}:
+    get:
+      tags:
+        - Documents > Document Renditions
+      summary: Download Document Rendition File
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Download_Document_Rendition_File
+
+
+
+        Download a rendition file from the latest version of a document.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: steadyState
+          in: query
+          schema:
+            type: string
+          description: >
+            Set to true to download a rendition (file) from the latest steady
+            state version (1.0, 2.0, etc.) of a document.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: rendition_type
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Documents > Document Renditions
+      summary: Add Single Document Rendition
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Upload_Document_Rendition
+
+
+
+        **Note:** If you need to add more than one document rendition, it is
+        best practice to use the <a
+        href="https://developer.veevavault.com/api/25.1/#Add_Document_Renditions_Bulk">bulk
+        API</a>.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content Type
+          in: header
+          schema:
+            type: string
+          example: multipart/form-data
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: rendition_type
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - Documents > Document Renditions
+      summary: Replace Document Rendition
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Replace_Document_Rendition
+
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: multipart/form-data
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: rendition_type
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Documents > Document Renditions
+      summary: Delete Single Document Rendition
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Delete_Document_Rendition
+
+
+
+        **Note:** If you need to delete more than one document rendition, it is
+        best practice to use the <a
+        href="https://developer.veevavault.com/api/25.1/#Delete_Document_Renditions">bulk
+        API</a>.
+
+
+        Delete a single document rendition. On SUCCESS, Vault deletes the
+        rendition of specified type from the latest document version.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: rendition_type
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/renditions/:{rendition_type}:
+    get:
+      tags:
+        - Documents > Document Renditions
+      summary: Download Document Version Rendition File
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Download_Document_Version_Rendition_File
+
+
+
+        Download a rendition for a specified version of a document.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: rendition_type
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Documents > Document Renditions
+      summary: Upload Document Version Rendition
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Upload_Document_Version_Rendition
+
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: multipart/form-data
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: rendition_type
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - Documents > Document Renditions
+      summary: Replace Document Version Rendition
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Replace_Document_Version_Rendition
+
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: multipart/form-data
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: rendition_type
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Documents > Document Renditions
+      summary: Delete Document Version Rendition
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Delete_Document_Version_Rendition
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: rendition_type
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/renditions/batch:
+    post:
+      tags:
+        - Documents > Document Renditions
+      summary: Add Multiple Document Renditions
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Add_Document_Renditions_Bulk
+
+
+
+        Add document renditions in bulk.
+
+
+        * If the `largeSizeAsset` query parameter is not set to `true`, you must
+        include the `X-VaultAPI-MigrationMode` header.
+
+        * The maximum CSV input file size is 1GB.
+
+        * The values in the input must be UTF-8 encoded.
+
+        * CSVs must follow the <a href
+        ="https://datatracker.ietf.org/doc/html/rfc4180">standard format.</a>
+
+        * The maximum batch size is 500.
+
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-MigrationMode
+          in: header
+          schema:
+            type: boolean
+          description: >-
+            Must be set to true when importing any rendition type other than
+            large_size_asset__v. You must have the Document Migration permission
+            to use this header. Learn more about <a
+            href="https://platform.veevavault.help/en/gr/54028">Document
+            Migration Mode in Vault Help.</a>
+          example: 'true'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: idParam
+          in: query
+          schema:
+            type: string
+          description: If you’re identifying documents in your input by their external ID
+        - name: largeSizeAsset
+          in: query
+          schema:
+            type: string
+          description: >-
+            If set to true, indicates that the renditions to add are of the
+            Large Size Asset (large_size_asset__v) rendition type. Vault applies
+            Document Migration Mode limitations to renditions created with the
+            request, but Document Migration permission is not required and your
+            vault need not be in Migration Mode to use the parameter. Note that
+            the request results in an error if the CSV contains any rendition
+            type other than large_size_asset__v.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Documents > Document Renditions
+      summary: Delete Multiple Document Renditions
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Delete_Document_Renditions
+
+
+
+        Delete document renditions in bulk.
+
+
+        * The maximum input file size is 1GB.
+
+        * The values in the input must be UTF-8 encoded.
+
+        * CSVs must follow the <a href
+        ="https://datatracker.ietf.org/doc/html/rfc4180">standard format.</a>
+
+        * The maximum batch size is 500.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/batch/actions/rerender:
+    post:
+      tags:
+        - Documents > Document Renditions
+      summary: Update Multiple Document Renditions
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Replace_Document_Rendition
+
+
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/attachments:
+    get:
+      tags:
+        - Documents > Document Attachments
+      summary: Retrieve Document Attachments
+      description: |+
+        https://developer.veevavault.com/api/25.1/#List_Document_Attachments
+
+
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Documents > Document Attachments
+      summary: Create Document Attachment
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Add_Document_Attachment
+
+
+
+        Create an attachment on the latest version of a document. If the
+        attachment already exists, Vault uploads the attachment as a new version
+        of the existing attachment. Learn more about <a
+        href="https://platform.veevavault.help/en/lr/24287#version-specific">attachment
+        versioning in Vault Help</a>.
+
+
+        To create a version-specific attachment, or to create multiple
+        attachments at once, use the <a
+        href="https://developer.veevavault.com/api/24.3#Create_Multiple_Attachments">bulk
+        API</a>.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: multipart/form-data
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/version/:{major_version}/:{minor_version}/attachments:
+    get:
+      tags:
+        - Documents > Document Attachments
+      summary: Retrieve Document Version Attachments
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Version_Attachments
+
+
+
+        Retrieve attachments on a specific version of a document.
+
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/attachments/:{attachment_id}/versions:
+    get:
+      tags:
+        - Documents > Document Attachments
+      summary: Retrieve Document Attachment Versions
+      description: >+
+        https://developer.veevavault.com/api/25.1/#List_Document_Attachment_Versions
+
+
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/attachments/:{attachment_id}/versions/:{attachment_version}:
+    get:
+      tags:
+        - Documents > Document Attachments
+      summary: Retrieve Document Version Attachment Versions
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Version_Attachment_Version
+
+
+
+        Retrieve versions of an attachment on a specific version of a document.
+
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/attachments/:{attachment_id}:
+    get:
+      tags:
+        - Documents > Document Attachments
+      summary: Retrieve Document Attachment Metadata
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Attachment_Metadata
+
+
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Documents > Document Attachments
+      summary: Delete Single Document Attachment
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Delete_Document_Attachment
+
+
+        Deletes the specified attachment and all of its versions.
+
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - Documents > Document Attachments
+      summary: Update Document Attachment Description
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Update_Document_Attachment_Description
+
+
+
+        Update an attachment on the latest version of a document. To update a
+        version-specific attachment, or to update multiple attachments at once,
+        use the <a
+        href="https://developer.veevavault.com/api/24.3#Update_Multiple_Attachments">bulk
+        API</a>.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/attachments/:{attachment_id}/versions/:{attachment_version}:
+    get:
+      tags:
+        - Documents > Document Attachments
+      summary: Retrieve Document Attachment Version Metadata
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Attachment_Version_Metadata
+
+
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Documents > Document Attachments
+      summary: Delete Single Document Attachment Version
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Delete_Document_Attachment_Version
+
+
+
+        Deletes the specified version of the specified attachment.
+
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Documents > Document Attachments
+      summary: Restore Document Attachment Version
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Restore_Document_Attachment_Version
+
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: restore
+          in: query
+          schema:
+            type: boolean
+          description: |
+            The parameter restore must be set to true.
+          example: 'true'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/attachments/:{attachment_id}/file:
+    get:
+      tags:
+        - Documents > Document Attachments
+      summary: Download Document Attachment
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Download_Document_Attachment_File
+
+
+
+        Downloads the latest version of the specified attachment from the
+        document.
+
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/attachments/:{attachment_id}/versions/:{attachment_version}/file:
+    get:
+      tags:
+        - Documents > Document Attachments
+      summary: Download Document Attachment Version
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Download_Document_Attachment_Version_File
+
+
+
+        Downloads the specified version of the attachment from the document.
+
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/attachments/:{attachment_id}/versions/:{attachment_version}/file:
+    get:
+      tags:
+        - Documents > Document Attachments
+      summary: Download Document Version Attachment Version
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Download_Document_Version_Attachment_Version
+
+
+
+        Downloads the specified attachment version from the specified document
+        version.
+
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/attachments/file:
+    get:
+      tags:
+        - Documents > Document Attachments
+      summary: Download All Document Attachments
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Download_All_Document_Attachment_Files
+
+
+
+        Downloads the latest version of all attachments from the document.
+
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/:{major_version}/:{minor_version}/attachments/file:
+    get:
+      tags:
+        - Documents > Document Attachments
+      summary: Download All Document Version Attachments
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Download_All_Document_Version_Attachments
+
+
+
+        Downloads the latest version of all attachments from the specified
+        version of the document.
+
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/attachments/batch:
+    delete:
+      tags:
+        - Documents > Document Attachments
+      summary: Delete Multiple Document Attachments
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Delete_Multiple_Attachments
+
+
+
+        Delete multiple document attachments in bulk with a JSON or CSV input
+        file. This works for version-specific attachments and attachments at the
+        document level.
+
+
+        * The maximum input file size is 1GB.
+
+        * The values in the input must be UTF-8 encoded.
+
+        * CSVs must follow the <a href
+        ="https://datatracker.ietf.org/doc/html/rfc4180">standard format.</a>
+
+        * The maximum batch size is 500.
+
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Documents > Document Attachments
+      summary: Create Multiple Document Attachments
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Create_Multiple_Attachments
+
+
+
+        Create multiple document attachments in bulk with a JSON or CSV input
+        file. You must first load the attachments to the <a
+        href="https://developer.veevavault.com/docs/#FTP">file staging
+        server</a>. This works for version-specific attachments and attachments
+        at the document level. If the attachment already exists, Vault uploads
+        the attachment as a new version of the existing attachment. Learn more
+        about <a
+        href="https://platform.veevavault.help/en/lr/24287#version-specific">attachment
+        versioning in Vault Help</a>.
+
+
+        * The maximum input file size is 1GB.
+
+        * The values in the input must be UTF-8 encoded.
+
+        * CSVs must follow the <a href
+        ="https://datatracker.ietf.org/doc/html/rfc4180">standard format.</a>
+
+        * The maximum batch size is 500.
+
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - Documents > Document Attachments
+      summary: Update Multiple Document Attachment Descriptions
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Update_Multiple_Attachments
+
+
+
+        Update multiple document attachments in bulk with a JSON or CSV input
+        file. This works for version-specific attachments and attachments at the
+        document level. You can only update the latest version of an attachment.
+
+
+        * The maximum input file size is 1GB.
+
+        * The values in the input must be UTF-8 encoded.
+
+        * CSVs must follow the <a href
+        ="https://datatracker.ietf.org/doc/html/rfc4180">standard format.</a>
+
+        * The maximum batch size is 500.
+
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/objects/documents/annotations/types/:{annotation_type}:
+    get:
+      tags:
+        - Documents > Document Annotations
+      summary: Retrieve Annotation Type Metadata
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Retrieve_Annotation_Type_Metadata](https://developer.veevavault.com/api/25.1/#Retrieve_Annotation_Type_Metadata)
+
+
+        Retrieves the metadata of an annotation type, including metadata and
+        value sets for all supported fields on the annotation type. Learn more
+        about [annotation types in the Vault Java SDK
+        documentation](https://developer.veevavault.com/sdk/#Annotation_Types).
+
+
+        On `SUCCESS`, the response includes a list of metadata information for
+        the specified annotation type.
+
+
+        **Request**
+
+
+        ``` bash
+
+        $ curl -X GET -H "Authorization: {SESSION_ID}" \
+
+        https://myvault.veevavault.com/api/v24.2/metadata/objects/documents/annotations/types/note__sys'
+        \
+
+         ```
+
+        **Response**
+
+
+        ``` json
+
+        {
+            "responseStatus": "SUCCESS",
+            "data": {
+                "name": "note__sys",
+                "allows_replies": true,
+                "allowed_placemark_types": [
+                    "arrow__sys",
+                    "ellipse__sys",
+                    "page_level__sys",
+                    "rectangle__sys",
+                    "sticky__sys",
+                    "text__sys"
+                ],
+                "allowed_reference_types": [],
+                "fields": [
+                    {
+                        "name": "created_by_delegate_user__sys",
+                        "type": "String",
+                        "system_managed": true,
+                        "value_set": []
+                    },
+                    {
+                        "name": "created_by_user__sys",
+                        "type": "String",
+                        "system_managed": true,
+                        "value_set": []
+                    },
+                    {
+                        "name": "created_date_time__sys",
+                        "type": "DateTime",
+                        "system_managed": true,
+                        "value_set": []
+                    },
+                    {
+                        "name": "document_version_id__sys",
+                        "type": "String",
+                        "system_managed": false,
+                        "value_set": []
+                    },
+                    {
+                        "name": "id__sys",
+                        "type": "String",
+                        "system_managed": true,
+                        "value_set": []
+                    },
+                    {
+                        "name": "modified_by_user__sys",
+                        "type": "String",
+                        "system_managed": true,
+                        "value_set": []
+                    },
+                    {
+                        "name": "modified_date_time__sys",
+                        "type": "DateTime",
+                        "system_managed": true,
+                        "value_set": []
+                    },
+                    {
+                        "name": "title__sys",
+                        "type": "String",
+                        "system_managed": false,
+                        "value_set": []
+                    },
+                    {
+                        "name": "color__sys",
+                        "type": "String",
+                        "system_managed": false,
+                        "value_set": [
+                            "yellow_light__sys",
+                            "green_dark__sys",
+                            "green_light__sys",
+                            "orange_dark__sys",
+                            "orange_light__sys",
+                            "pink_dark__sys",
+                            "pink_light__sys",
+                            "purple_dark__sys",
+                            "purple_light__sys",
+                            "red_dark__sys",
+                            "red_light__sys",
+                            "yellow_dark__sys"
+                        ]
+                    },
+                    {
+                        "name": "comment__sys",
+                        "type": "String",
+                        "system_managed": false,
+                        "value_set": []
+                    },
+                    {
+                        "name": "original_source_document_version_id__sys",
+                        "type": "String",
+                        "system_managed": true,
+                        "value_set": []
+                    },
+                    {
+                        "name": "reply_count__sys",
+                        "type": "Number",
+                        "system_managed": true,
+                        "value_set": []
+                    },
+                    {
+                        "name": "state__sys",
+                        "type": "String",
+                        "system_managed": false,
+                        "value_set": [
+                            "open__sys",
+                            "resolved__sys"
+                        ]
+                    },
+                    {
+                        "name": "tag_names__sys",
+                        "type": "String list",
+                        "system_managed": false,
+                        "value_set": []
+                    },
+                    {
+                        "name": "type__sys",
+                        "type": "String",
+                        "system_managed": false,
+                        "value_set": [
+                            "note__sys"
+                        ]
+                    }
+                ]
+            }
+        }
+
+         ```
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: annotation_type
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/objects/documents/annotations/placemarks/types/:{placemark_type}:
+    get:
+      tags:
+        - Documents > Document Annotations
+      summary: Retrieve Annotation Placemark Type Metadata
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Retrieve_Annotation_Placemark_Type_Metadata](https://developer.veevavault.com/api/25.1/#Retrieve_Annotation_Placemark_Type_Metadata%22)
+
+
+        Retrieves the metadata of a specified annotation placemark type. Learn
+        more about [placemark types in the Vault Java SDK
+        documentation](https://developer.veevavault.com/sdk/#Annotation_Placemarks).
+
+
+        On `SUCCESS`, the response includes a list of metadata information for
+        the specified placemark type.
+
+
+        **Request**
+
+
+        ``` bash
+
+        $ curl -X GET -H "Authorization: {SESSION_ID}" \
+
+        https://myvault.veevavault.com/api/v24.2/metadata/objects/documents/annotations/placemarks/types/arrow__sys
+        \
+
+         ```
+
+        **Response**
+
+
+        ``` json
+
+        {
+            "responseStatus": "SUCCESS",
+            "data": {
+                "name": "arrow__sys",
+                "fields": [
+                    {
+                        "name": "coordinates__sys",
+                        "type": "Number list",
+                        "system_managed": false,
+                        "value_set": []
+                    },
+                    {
+                        "name": "height__sys",
+                        "type": "Number",
+                        "system_managed": false,
+                        "value_set": []
+                    },
+                    {
+                        "name": "width__sys",
+                        "type": "Number",
+                        "system_managed": false,
+                        "value_set": []
+                    },
+                    {
+                        "name": "x_coordinate__sys",
+                        "type": "Number",
+                        "system_managed": false,
+                        "value_set": []
+                    },
+                    {
+                        "name": "y_coordinate__sys",
+                        "type": "Number",
+                        "system_managed": false,
+                        "value_set": []
+                    },
+                    {
+                        "name": "page_number__sys",
+                        "type": "Number",
+                        "system_managed": false,
+                        "value_set": []
+                    },
+                    {
+                        "name": "style__sys",
+                        "type": "String",
+                        "system_managed": false,
+                        "value_set": [
+                            "arrow_down_left__sys",
+                            "arrow_down_right__sys",
+                            "arrow_left_down__sys",
+                            "arrow_left_up__sys",
+                            "arrow_right_down__sys",
+                            "arrow_right_up__sys",
+                            "arrow_up_left__sys",
+                            "arrow_up_right__sys"
+                        ]
+                    },
+                    {
+                        "name": "type__sys",
+                        "type": "String",
+                        "system_managed": false,
+                        "value_set": [
+                            "arrow__sys"
+                        ]
+                    }
+                ]
+            }
+        }
+
+         ```
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: placemark_type
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/objects/documents/annotations/references/types/:{reference_type}:
+    get:
+      tags:
+        - Documents > Document Annotations
+      summary: Retrieve Annotation Reference Type Metadata
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Retrieve_Annotation_Reference_Type_Metadata](https://developer.veevavault.com/api/25.1/#Retrieve_Annotation_Reference_Type_Metadata)
+
+
+        Retrieves the metadata of a specified annotation reference type. Learn
+        more about [reference types in the Vault Java SDK
+        documentation](https://developer.veevavault.com/sdk/#Annotation_References).
+
+
+        On `SUCCESS`, the response includes a list of annotations of the
+        specified type(s) for the document version.
+
+
+        **Request**
+
+
+        ``` bash
+
+        $ curl -X GET -H "Authorization: {SESSION_ID}" \
+
+        https://myvault.veevavault.com/api/v24.2/metadata/objects/documents/annotations/references/types/document__sys
+        \
+
+         ```
+
+        **Response**
+
+
+        ``` json
+
+        {
+            "responseStatus": "SUCCESS",
+            "data": {
+                "name": "document__sys",
+                "fields": [
+                    {
+                        "name": "annotation__sys",
+                        "type": "String",
+                        "system_managed": false,
+                        "value_set": []
+                    },
+                    {
+                        "name": "document_version_id__sys",
+                        "type": "String",
+                        "system_managed": false,
+                        "value_set": []
+                    },
+                    {
+                        "name": "type__sys",
+                        "type": "String",
+                        "system_managed": true,
+                        "value_set": [
+                            "document__sys"
+                        ]
+                    }
+                ]
+            }
+        }
+
+         ```
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: reference_type
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/annotations/batch:
+    post:
+      tags:
+        - Documents > Document Annotations
+      summary: Create Multiple Annotations
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Create_Multiple_Annotations](https://developer.veevavault.com/api/25.1/#Create_Multiple_Annotations)
+
+
+        Create up to 500 annotations.
+
+
+        Prepare a JSON-formatted list of annotation objects, each containing a
+        list of annotation properties and their values. For more details about
+        annotation fields, see [Read Annotations by Document Version and
+        Type](https://developer.veevavault.com/api/25.1/#Read_Annotations_by_Document_Version_and_Type).
+
+
+        On `SUCCESS`, the response includes a `responseStatus` indicating
+        whether each annotation object in the request body was successfully
+        created.
+
+
+        **Request**
+
+
+        ``` bash
+
+        $ curl -X POST -H "Authorization: {SESSION_ID}" \
+
+        -H 'Content-Type: application/json' \
+
+        -H 'Accept: application/json' \
+
+        -d '[
+           {
+               "type__sys": "note__sys",
+               "document_version_id__sys": "1_0_1",
+               "color__sys": "orange_dark__sys",
+               "comment__sys": "hello world",
+               "placemark": {
+                   "type__sys": "sticky__sys",
+                   "page_number__sys": 1,
+                   "x_coordinate__sys": 50.5,
+                   "y_coordinate__sys": 25.5
+               }
+           },
+           {
+               "type__sys": "document_link__sys",
+               "document_version_id__sys": "2_0_1",
+               "placemark": {
+                   "type__sys": "text__sys",
+                   "page_number__sys": 2,
+                   "text_start_index__sys": 10,
+                   "text_end_index__sys": 15
+               },
+               "references": [
+                   {
+                       "type__sys": "document__sys",
+                       "document_version_id__sys": "301_0_3",
+                       "annotation__sys": "56"
+                   },
+                   {
+                       "type__sys": "document__sys",
+                       "document_version_id__sys": "4_0_1"
+                   }
+               ]
+           }
+        ]'
+
+        https://myvault.veevavault.com/api/v24.2/objects/documents/annotations/batch
+        \
+
+         ```
+
+        **Response**
+
+
+        ``` json
+
+        {
+            "responseStatus": "SUCCESS",
+            "data": [
+                {
+                    "responseStatus": "SUCCESS",
+                    "document_version_id__sys": "1_0_1",
+                    "global_version_id__sys": "123456_1_1",
+                    "id__sys": "58"
+                },
+                {
+                    "responseStatus": "SUCCESS",
+                    "document_version_id__sys": "2_0_1",
+                    "global_version_id__sys": "123456_2_2",
+                    "id__sys": "59"
+                }
+            ]
+        }
+
+         ```
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - Documents > Document Annotations
+      summary: Update Annotations
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Update_Multiple_Annotations](https://developer.veevavault.com/api/25.1/#Update_Multiple_Annotations)
+
+
+        Update up to 500 existing annotations.
+
+
+        Prepare a JSON-formatted list of annotation objects. Each object must
+        contain the id_sys, document_version_id__sys, and the annotation
+        field(s) to be updated. For more details about annotation fields, see
+        [Read Annotations by Document Version and
+        Type](https://developer.veevavault.com/api/25.1/#Read_Annotations_by_Document_Version_and_Type).
+
+
+        On `SUCCESS`, the response includes the document version ID, global
+        version ID, and ID and version of updated annotations. See [Create
+        Annotations](https://developer.veevavault.com/api/25.1/#Create_Multiple_Annotations)
+        for details. Annotations that did not update successfully are reported
+        with an error message.
+
+
+        **Request**
+
+
+        ``` bash
+
+        $ curl -X PUT -H "Authorization: {SESSION_ID}" \
+
+        -H 'Content-Type: application/json' \
+
+        -H 'Accept: application/json' \
+
+        -d '[
+           {
+               "id__sys": "58",
+               "document_version_id__sys": "1_0_1",
+               "comment__sys": "Updated comment from api"
+           },
+           {
+               "id__sys": "54",
+               "document_version_id__sys": "1_0_1",
+               "color__sys": "yellow_light__sys"
+           }
+        ]'
+
+        https://myvault.veevavault.com/api/v24.2/objects/documents/annotations/batch
+
+         ```
+
+        **Response**
+
+
+        ``` json
+
+        {
+            "responseStatus": "SUCCESS",
+            "data": [
+                {
+                    "responseStatus": "SUCCESS",
+                    "document_version_id__sys": "1_0_1",
+                    "global_version_id__sys": "123456_1_1",
+                    "id__sys": "58"
+                },
+                {
+                    "responseStatus": "SUCCESS",
+                    "document_version_id__sys": "1_0_1",
+                    "global_version_id__sys": "123456_1_1",
+                    "id__sys": "54"
+                }
+            ]
+        }
+
+         ```
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Documents > Document Annotations
+      summary: Delete Annotations
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Delete_Annotations](https://developer.veevavault.com/api/25.1/#Delete_Annotations)
+
+
+        Delete multiple annotations. You must have _Annotate_ permission on the
+        specified document versions to delete annotations.
+
+
+        Some HTTP clients do not support `DELETE` requests with a body. As a
+        workaround for these cases, you can simulate this request using the
+        `POST` method and using the `_method=DELETE` query parameter.
+
+
+        Upload parameters as a JSON or CSV file. You can delete up to 500
+        annotations per batch.
+
+
+        **Request**
+
+
+        ``` bash
+
+        $ curl -X DELETE -H "Authorization: {SESSION_ID}" \
+
+        -H "Content-Type: text/csv" \
+
+        --data-binary @"C:\Vault\Documents\delete_annotations.csv" \
+
+        https://myvault.veevavault.com/api/v24.2/objects/documents/annotations/batch
+
+         ```
+
+        **Response**
+
+
+        ``` json
+
+        {
+           "responseStatus": "SUCCESS",
+           "data": [
+               {
+                   "responseStatus": "SUCCESS",
+                   "document_version_id__sys": "1_0_1",
+                   "id__sys": "58",
+                   "global_version_id__sys": "119899_1_1"
+               }
+           ]
+        }
+
+         ```
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/annotations/replies/batch:
+    post:
+      tags:
+        - Documents > Document Annotations
+      summary: Add Annotation Replies
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Add_Annotation_Replies](https://developer.veevavault.com/api/25.1/#Add_Annotation_Replies)
+
+
+        Create up to 500 annotation replies.
+
+
+        Prepare a JSON-formatted list of annotation reply objects. Each object
+        must contain the `id_sys`, `document_version_id__sys`, and the
+        annotation field(s) to be set, and a `placemark` object containing the
+        `type__sys` and `reply_parent__sys` fields.
+
+
+        On `SUCCESS`, the response includes the document version ID, global
+        version ID, and ID and version of each successfully created reply. See
+        [Create
+        Annotations](https://developer.veevavault.com/api/25.1/#Create_Multiple_Annotations)
+        for details. Replies that were not added successfully are reported with
+        an error message.
+
+
+        **Request**
+
+
+        ``` bash
+
+        $ curl -X POST -H "Authorization: {SESSION_ID}" \
+
+        -H 'Content-Type: application/json' \
+
+        -H 'Accept: application/json' \
+
+        -d '[
+           {
+               "document_version_id__sys": "1_0_1",
+               "type__sys": "reply__sys",
+               "comment__sys": "first reply from the api",
+               "placemark": {
+                   "type__sys": "reply__sys",
+                   "reply_parent__sys": "54"
+               }
+           },
+           {
+               "document_version_id__sys": "1_0_1",
+               "type__sys": "reply__sys",
+               "color__sys": "green_light__sys",
+               "comment__sys": "first reply from the api",
+               "placemark": {
+                   "type__sys": "reply__sys",
+                   "reply_parent__sys": "55"
+               }
+           },
+           {
+               "document_version_id__sys": "1_0_1",
+               "type__sys": "reply__sys",
+               "comment__sys": "second reply from the api",
+               "placemark": {
+                   "type__sys": "reply__sys",
+                   "reply_parent__sys": "54"
+               }
+           }
+        ]'
+
+        https://myvault.veevavault.com/api/v24.2/objects/documents/annotations/replies/batch
+        \
+
+         ```
+
+        **Response**
+
+
+        ``` json
+
+        {
+            "responseStatus": "SUCCESS",
+            "data": [
+                {
+                    "responseStatus": "SUCCESS",
+                    "document_version_id__sys": "1_0_1",
+                    "global_version_id__sys": "123456_1_1",
+                    "id__sys": "60"
+                },
+                {
+                    "responseStatus": "SUCCESS",
+                    "document_version_id__sys": "1_0_1",
+                    "global_version_id__sys": "123456_1_1",
+                    "id__sys": "62"
+                },
+                {
+                    "responseStatus": "SUCCESS",
+                    "document_version_id__sys": "1_0_1",
+                    "global_version_id__sys": "123456_1_1",
+                    "id__sys": "61"
+                }
+            ]
+        }
+
+         ```
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/annotations:
+    get:
+      tags:
+        - Documents > Document Annotations
+      summary: Read Annotations by Document Version and Type
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Read_Annotations_by_Document_Version_and_Type](https://developer.veevavault.com/api/25.1/#Read_Annotations_by_Document_Version_and_Type)
+
+
+        Retrieve annotations from a specific document version. You can retrieve
+        all annotations or choose to retrieve only certain annotation types.
+
+
+        You must have _View Content_ permission on the specified document
+        version.
+
+
+        On `SUCCESS`, the response includes a list of annotations of the
+        specified type(s) for the document version.
+
+
+        **Request**
+
+
+        ``` bash
+
+        $ curl -X GET -H "Authorization: {SESSION_ID}" \
+
+        https://myvault.veevavault.com/api/v24.2/objects/documents/47/versions/0/1/annotations?annotation_types=document_link__sys,note__sys
+
+         ```
+
+        **Response**
+
+
+        ``` json
+
+        {
+            "responseStatus": "SUCCESS",
+            "data": [
+                {
+                    "document_version_id__sys": "47_0_1",
+                    "modified_by_user__sys": "1003079",
+                    "id__sys": "15",
+                    "placemark": {
+                        "y_coordinate__sys": 474.32,
+                        "coordinates__sys": [
+                            481.01,
+                            474.32,
+                            598.37,
+                            474.32,
+                            481.01,
+                            363.04,
+                            598.37,
+                            363.04
+                        ],
+                        "type__sys": "rectangle__sys",
+                        "height__sys": 111.28,
+                        "width__sys": 117.36,
+                        "x_coordinate__sys": 481.01,
+                        "page_number__sys": 1,
+                        "style__sys": "rectangle_solid__sys"
+                    },
+                    "created_by_user__sys": "1003079",
+                    "comment__sys": "Make this green.",
+                    "created_date_time__sys": "2023-06-26T19:59:41.000Z",
+                    "modified_date_time__sys": "2024-03-04T18:47:43.000Z",
+                    "title__sys": "",
+                    "type__sys": "note__sys",
+                    "tag_names__sys": [
+                        "CholeCap"
+                    ],
+                    "state__sys": "open__sys",
+                    "reply_count__sys": 0,
+                    "color__sys": "yellow_light__sys"
+                },
+                {
+                    "document_version_id__sys": "47_0_1",
+                    "modified_by_user__sys": "1003079",
+                    "references": [
+                        {
+                            "document_version_id__sys": "7_1_0",
+                            "type__sys": "document__sys",
+                            "annotation__sys": "21"
+                        }
+                    ],
+                    "id__sys": "22",
+                    "placemark": {
+                        "y_coordinate__sys": 491.46,
+                        "coordinates__sys": [
+                            349.48,
+                            491.46,
+                            408.54,
+                            491.46,
+                            349.48,
+                            454.25,
+                            408.54,
+                            454.25
+                        ],
+                        "type__sys": "rectangle__sys",
+                        "height__sys": 37.21,
+                        "width__sys": 59.06,
+                        "x_coordinate__sys": 349.48,
+                        "page_number__sys": 1,
+                        "style__sys": "rectangle_solid__sys"
+                    },
+                    "created_by_user__sys": "1003079",
+                    "comment__sys": "",
+                    "created_date_time__sys": "2024-03-04T18:51:54.000Z",
+                    "modified_date_time__sys": "2024-03-04T18:52:16.000Z",
+                    "title__sys": "",
+                    "type__sys": "document_link__sys",
+                    "state__sys": "open__sys",
+                    "color__sys": "blue_dark__sys"
+                }
+            ],
+            "responseDetails": {
+                "offset": 0,
+                "limit": 500,
+                "size": 2,
+                "total": 2
+            }
+        }
+
+         ```
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: limit
+          in: query
+          schema:
+            type: string
+          description: >-
+            Paginate the results by specifying the maximum number of records per
+            page in the response. This can be any value between 1 and 500. If
+            omitted, defaults to 500. Values greater than 500 are ignored.
+        - name: offset
+          in: query
+          schema:
+            type: string
+          description: >-
+            This parameter is used to paginate the results. It specifies the
+            amount of offset from the first record returned. Vault returns 200
+            records per page by default. If you are viewing the first 200
+            results (page 1) and want to see the next page, set this to
+            offset=201.
+        - name: annotation_types
+          in: query
+          schema:
+            type: string
+          description: >
+            The type(s) of annotations to retrieve. For example,
+            note__sys,anchor__sys. If omitted, Vault returns all annotations.
+            Valid annotation types include:
+
+            `note__sys`
+
+            `line__sys`
+
+            `document_link__sys`
+
+            `permalink_link__sys`
+
+            `anchor__sys`
+
+            `reply__sys`
+
+            `external_link__sys`
+
+
+            The following annotation types are only valid in PromoMats Vaults:
+
+
+            `suggested_link__sys`
+
+            `approved_link__sys`
+
+            `auto_link__sys`
+
+            `keyword_link__sys`
+        - name: pagination_id
+          in: query
+          schema:
+            type: string
+          description: A unique identifier used to load requests with paginated results.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/annotations/:{annotation_id}:
+    get:
+      tags:
+        - Documents > Document Annotations
+      summary: Read Annotations by ID
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Read_Annotations_by_ID](https://developer.veevavault.com/api/25.1/#Read_Annotations_by_ID)
+
+
+        Retrieve a specific annotation by the annotation ID. You must have _View
+        Content_ permission on the document version containing the specified ID.
+
+
+        On `SUCCESS`, the response includes all fields and values for the
+        specified annotation. For more details about annotation fields, see
+        [Read Annotations by Document Version and
+        Type](https://developer.veevavault.com/api/25.1/#Read_Annotations_by_Document_Version_and_Type).
+
+
+        **Request**
+
+
+        ``` bash
+
+        $ curl -X GET -H "Authorization: {SESSION_ID}" \
+
+        https://myvault.veevavault.com/api/v24.2/objects/documents/102/versions/0/2/annotations/40**
+
+         ```
+
+        **Response**
+
+
+        ``` json
+
+        {
+            "responseStatus": "SUCCESS",
+            "data": [
+                {
+                    "document_version_id__sys": "102_0_2",
+                    "modified_by_user__sys": "133999",
+                    "id__sys": "40",
+                    "placemark": {
+                        "y_coordinate__sys": 469.97,
+                        "coordinates__sys": [
+                            239.56,
+                            469.97,
+                            408.11,
+                            469.97,
+                            239.56,
+                            199.16,
+                            408.11,
+                            199.16
+                        ],
+                        "type__sys": "line__sys",
+                        "height__sys": 270.81,
+                        "width__sys": 168.55,
+                        "x_coordinate__sys": 239.56,
+                        "page_number__sys": 1,
+                        "style__sys": "line_weight_two__sys"
+                    },
+                    "created_by_user__sys": "133999",
+                    "comment__sys": "Replace image",
+                    "created_date_time__sys": "2024-02-07T00:18:57.000Z",
+                    "modified_date_time__sys": "2024-02-07T00:18:57.000Z",
+                    "title__sys": "",
+                    "type__sys": "line__sys",
+                    "tag_names__sys": [
+                        "IMG"
+                    ],
+                    "state__sys": "open__sys",
+                    "reply_count__sys": 0,
+                    "color__sys": "red_dark__sys"
+                }
+            ]
+        }
+
+         ```
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: ''
+          in: query
+          schema:
+            type: string
+        - name: ''
+          in: query
+          schema:
+            type: string
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: annotation_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/annotations/:{annotation_id}/replies:
+    get:
+      tags:
+        - Documents > Document Annotations
+      summary: Read Replies of Parent Annotation
+      description: "[https://developer.veevavault.com/api/25.1/#Read_Replies_of_Parent_Annotation](https://developer.veevavault.com/api/25.1/Read_Replies_of_Parent_Annotation).\n\nGiven a parent annotation ID, retrieves all replies to the annotation. You must have _View Content_ permission on the document version containing the specified parent annotation ID.\n\nOn\_`SUCCESS`, the response lists all fields and values for all replies to the specified annotation. For more details about annotation fields, see\_[Read Annotations by Document Version and Type](https://developer.veevavault.com/api/24.1/#Read_Annotations_by_Document_Version_and_Type).\n\n**Request**\n\n```bash\n$ curl -X GET -H \"Authorization: {SESSION_ID}\" \\\nhttps://myvault.veevavault.com/api/v24.1/objects/documents/102/versions/0/2/annotations/40/replies\n```\n**Response**\n\n```json\n{\n    \"responseStatus\": \"SUCCESS\",\n    \"data\": [\n        {\n            \"document_version_id__sys\": \"102_0_2\",\n            \"modified_by_user__sys\": \"133999\",\n            \"type__sys\": \"reply__sys\",\n            \"id__sys\": \"41\",\n            \"tag_names__sys\": [\n                \"IMG\"\n            ],\n            \"state__sys\": \"open__sys\",\n            \"placemark\": {\n                \"reply_position_index__sys\": 1,\n                \"type__sys\": \"reply__sys\",\n                \"reply_parent__sys\": \"40\"\n            },\n            \"created_by_user__sys\": \"133999\",\n            \"comment__sys\": \"I think this image is fine.\",\n            \"created_date_time__sys\": \"2024-02-07T00:37:36.000Z\",\n            \"modified_date_time__sys\": \"2024-02-07T00:37:36.000Z\",\n            \"color__sys\": \"red_dark__sys\"\n        }\n    ],\n    \"responseDetails\": {\n        \"offset\": 0,\n        \"limit\": 500,\n        \"size\": 1,\n        \"total\": 1\n    }\n}\n```"
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: annotation_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/annotations/file:
+    get:
+      tags:
+        - Documents > Document Annotations
+      summary: Export Document Annotations to PDF
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Retrieve_Document_Annotations](https://developer.veevavault.com/api/25.1/#Retrieve_Document_Annotations)
+
+
+        Export the latest version of any document, along with its annotations,
+        as an annotated PDF. This is equivalent to the _Export Annotations_
+        action in the Vault document viewer UI. You can then view annotations,
+        reply to existing annotations, and create new annotations in a
+        [supported PDF
+        editor](https://platform.veevavault.help/en/lr/23833#supported-pdf-editors).
+        When finished, you can import your new notes and replies to Vault using
+        the [Import Document Annotations from
+        PDF](https://eveloper.veevavault.com/api/25.1/#Upload_Document_Annotations)
+        endpoint.
+
+
+        You must have _View Content_ permission on the latest document version
+        and a security profile that grants the _Document: Download Rendition_
+        permission to export annotations.
+
+
+        On `SUCCESS`, Vault retrieves the specified version document rendition
+        and its associated annotations in PDF format.
+
+
+        - The HTTP Response Header `Content-Type` is set to `application/pdf`.
+
+        - The HTTP Response Header `Content-Disposition` contains a `filename`
+        component which is used as the default name for the local file.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Documents > Document Annotations
+      summary: Import Document Annotations from PDF
+      description: "[https://developer.veevavault.com/api/25.1/#Upload_Document_Annotations](https://developer.veevavault.com/api/25.1/#Upload_Document_Annotations)\n\nLoad annotations from a PDF to Vault. This is equivalent to the\__Import Annotations_\_action in the Vault document viewer UI. The file must be a PDF created by exporting annotations for the latest version of the same document through either the\__Export Annotations_\_action in the Vault UI or the\_[Export Document Annotations as PDF](https://developer.veevavault.com/api/25.1/#Retrieve_Document_Annotations)\_endpoint. You must have a role on the document that includes the\__Annotate_\_permission.\n\nTo upload the file, use the multi-part attachment with the file component\_`\"file={file_name}\"`. The maximum allowed file size is 4GB. Vault truncates annotations that exceed the following character limits:\n\n- **Note annotations**:\__Subject_\_(in Header) limited to 32,000 characters\n    \n- **Note, Line, and Reply annotations**:\__Comment_\_limited to 32,000 characters\n    \n\nOn\_`SUCCESS`, Vault uploads the file and its annotations."
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: multipart/form-data
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/annotations/file:
+    get:
+      tags:
+        - Documents > Document Annotations
+      summary: Export Document Version Annotations to PDF
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Retrieve_Document_Version_Annotations](https://developer.veevavault.com/api/25.1/#Retrieve_Document_Version_Annotations)
+
+
+        Export a specific version of any document, along with its annotations,
+        as an annotated PDF. This is equivalent to the _Export Annotations_
+        action in the Vault document viewer UI. You can then view annotations,
+        reply to existing annotations, and create new annotations in a supported
+        PDF editor. When finished, you can import your new notes and replies to
+        Vault using the [Import Document Version Annotations from
+        PDF](https://developer.veevavault.com/api/25.1/#Upload_Document_Version_Annotations)
+        endpoint.
+
+
+        You must have _View Content_ permission on the specified document
+        version and a security profile that grants the _Document: Download
+        Rendition_ permission to export annotations.
+
+
+        On `SUCCESS`, Vault retrieves the specified version document rendition
+        and its associated annotations in PDF format.
+
+
+        - The HTTP Response Header `Content-Type` is set to `application/pdf`.
+
+        - The HTTP Response Header `Content-Disposition` contains a `filename`
+        component which is used as the default name for the local file.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Documents > Document Annotations
+      summary: Import Document Version Annotations from PDF
+      description: "[https://developer.veevavault.com/api/25.1/#Upload_Document_Version_Annotations](https://developer.veevavault.com/api/25.1/#Upload_Document_Version_Annotations)\n\nLoad annotations from a PDF to Vault. This is equivalent to the\__Import Annotations_\_action in the Vault document viewer UI. The file must be a PDF created by exporting annotations for the specified version of the same document through either the\__Export Annotations_\_action in the Vault UI or the\_[Export Document Version Annotations as PDF](https://developer.veevavault.com/api/25.1/#Retrieve_Document_Version_Annotations)\_endpoint. You must have a role on the document that includes the\__Annotate_\_permission.\n\nTo upload the file, use the multi-part attachment with the file component\_`\"file={file_name}\"`. The maximum allowed file size is 4GB. Vault truncates annotations that exceed the following character limits:\n\n- **Note annotations**:\__Subject_\_(in Header) limited to 32,000 characters\n    \n- **Note, Line, and Reply annotations**:\__Comment_\_limited to 32,000 characters\n    \n\nOn\_`SUCCESS`, Vault uploads the file and its annotations."
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: multipart/form-data
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/anchors:
+    get:
+      tags:
+        - Documents > Document Annotations
+      summary: Retrieve Anchor IDs
+      description: "[https://developer.veevavault.com/api/25.1/#Retrieve_Anchor_IDs](https://developer.veevavault.com/api/25.1/#Retrieve_Anchor_IDs)\n\nRetrieve all anchor IDs from a document. You must have the\__View Document_\_permission to retrieve anchor IDs."
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/doc-export-annotations-to-csv:
+    get:
+      tags:
+        - Documents > Document Annotations
+      summary: Retrieve Document Version Notes as CSV
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Version_Notes_as_CSV
+
+
+
+        Retrieve notes in CSV format for any document that has a viewable
+        rendition and at least one annotation. You must have a *Full User*
+        license type.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/export-video-annotations:
+    get:
+      tags:
+        - Documents > Document Annotations
+      summary: Retrieve Video Annotations
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Video_Annotations
+
+
+
+        Retrieve annotations on any version of a document with a video file as
+        its viewable rendition. You must have the _View Content_ permission on
+        the specified document version to retrieve video annotations.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          description: >-
+            This `Accept` header only changes the format of the response in the
+            case of an error. On `SUCCESS`, the HTTP Response Header
+            `Content-Type` is set to `text/plain;charset=UnicodeLittle`.
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/objects/documents/types/:{type}/relationships:
+    get:
+      tags:
+        - Documents > Document Relationships
+      summary: Retrieve Document Type Relationships
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Type_Relationships
+
+
+
+        Retrieve all relationships from a document type.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: type
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/relationships:
+    get:
+      tags:
+        - Documents > Document Relationships
+      summary: Retrieve Document Relationships
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Relationships
+
+
+
+        Retrieve all relationships from a document.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Documents > Document Relationships
+      summary: Create Single Document Relationship
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Create_Document_Relationship
+
+
+
+        **Note:** If you need to create a relationship on more than one
+        document, it is best practice to use the <a
+        href="https://developer.veevavault.com/api/25.1/#Create_Document_Relationships">bulk
+        API</a>.
+
+
+        Create a new relationship on a document.
+
+
+        You cannot create or delete standard relationship types. Examples of
+        standard relationship types include *Based On* and *Original Source*.
+        Learn about Document Relationships in <a
+        href="https://platform.veevavault.help/en/lr/21330">Vault Help</a>.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/relationships/batch:
+    post:
+      tags:
+        - Documents > Document Relationships
+      summary: Create Multiple Document Relationships
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Create_Document_Relationships
+
+
+
+        Create new relationships on multiple documents.
+
+
+        * The maximum input file size is 1GB.
+
+        * The values in the input must be UTF-8 encoded.
+
+        * CSVs must follow the <a href
+        ="https://datatracker.ietf.org/doc/html/rfc4180">standard format.</a>
+
+        * The maximum batch size is 1000.
+
+
+        You cannot create or delete standard relationship types. Examples of
+        standard relationship types include *Based On* and *Original Source*.
+        Learn about Document Relationships in <a
+        href="https://platform.veevavault.help/en/lr/21330">Vault Help</a>.
+
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Documents > Document Relationships
+      summary: Delete Multiple Document Relationships
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Delete_Document_Relationships
+
+
+
+        Delete relationships from multiple documents.
+
+
+        * The maximum input file size is 1GB.
+
+        * The values in the input must be UTF-8 encoded.
+
+        * CSVs must follow the <a href
+        ="https://datatracker.ietf.org/doc/html/rfc4180">standard format.</a>
+
+        * The maximum batch size is 1000.
+
+
+        You cannot create or delete standard relationship types. Examples of
+        standard relationship types include *Based On* and *Original Source*.
+        Learn about Document Relationships in <a
+        href="https://platform.veevavault.help/en/lr/21330">Vault Help</a>.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/relationships/:{relationship_id}:
+    get:
+      tags:
+        - Documents > Document Relationships
+      summary: Retrieve Document Relationship
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Relationship
+
+
+
+        Retrieve details of a specific document relationship.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: relationship_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Documents > Document Relationships
+      summary: Delete Single Document Relationship
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Delete_Document_Relationship
+
+
+
+        **Note:** If you need to delete a relationship on more than one
+        document, it is best practice to use the <a
+        href="https://developer.veevavault.com/api/25.1/#Delete_Document_Relationships">bulk
+        API</a>.
+
+
+        Delete a relationship from a document.
+
+
+        You cannot create or delete standard relationship types. Examples of
+        standard relationship types include *Based On* and *Original Source*.
+        Learn about Document Relationships in <a
+        href="https://platform.veevavault.help/en/lr/21330">Vault Help</a>.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: relationship_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/batch/actions/fileextract:
+    post:
+      tags:
+        - Documents > Export Documents
+      summary: Export Documents
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Export_Documents
+
+
+
+        Use this request to export a set of documents to your Vault's <a
+        href="https://developer.veevavault.com/docs/#FTP">file staging
+        server</a>.
+
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                - id: '58'
+                - id: '134'
+                - id: '122'
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: source
+          in: query
+          schema:
+            type: boolean
+          description: >-
+            Optional: To exclude source files, include a query parameter
+            source=false. If omitted, defaults to true.
+          example: 'true'
+        - name: renditions
+          in: query
+          schema:
+            type: boolean
+          description: >-
+            Optional: To include renditions, include a query parameter
+            renditions=true. If omitted, defaults to false.
+          example: 'false'
+        - name: allversions
+          in: query
+          schema:
+            type: boolean
+          description: >-
+            Optional: To include all versions or latest version, include a query
+            parameter allversions=true. If omitted, defaults to false.
+          example: 'true'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/versions/batch/actions/fileextract:
+    post:
+      tags:
+        - Documents > Export Documents
+      summary: Export Document Versions
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Export_Document_Version
+
+
+
+        Export a specific set of document versions to your Vault's <a
+        href="https://developer.veevavault.com/docs/#FTP">file staging
+        server</a>. The files you export go to the u{userID} folder, regardless
+        of your security profile.
+
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                - id: '123'
+                  major_version_number__v: '0'
+                  minor_version_number__v: '1'
+                - id: '456'
+                  major_version_number__v: '1'
+                  minor_version_number__v: '0'
+                - id: '456'
+                  major_version_number__v: '2'
+                  minor_version_number__v: '0'
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: source
+          in: query
+          schema:
+            type: boolean
+          description: >-
+            Optional: To exclude source files, include a query parameter
+            source=false. If omitted, defaults to true.
+          example: 'true'
+        - name: renditions
+          in: query
+          schema:
+            type: boolean
+          description: >-
+            Optional: To include renditions, include a query parameter
+            renditions=true. If omitted, defaults to false.
+          example: 'false'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/batch/actions/fileextract/:{job_id}/results:
+    get:
+      tags:
+        - Documents > Export Documents
+      summary: Retrieve Document Export Results
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Export_Results
+
+
+
+        After submitting a request to export documents from your Vault, you can
+        query your Vault to determine the results of the request.
+
+
+        Before submitting this request:
+
+
+        * You must have previously requested a document export job (via the API)
+        which is no longer active.
+
+        * You must have a valid `job_id` value (retrieved from the document
+        export binder request above).
+
+        * You must be a Vault Owner, System Admin or the user who initiated the
+        job.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: job_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/objects/documents/events:
+    get:
+      tags:
+        - Documents > Document Events
+      summary: Retrieve Document Event Types and Subtypes
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Event_Types_and_Subtypes
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/objects/documents/events/:{event_type}/types/:{event_subtype}:
+    get:
+      tags:
+        - Documents > Document Events
+      summary: Retrieve Document Event SubType Metadata
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Event_SubType_Metadata
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: event_type
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: event_subtype
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/versions/:{major_version}/:{minor_version}/events:
+    post:
+      tags:
+        - Documents > Document Events
+      summary: Create Document Event
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Create_Document_Event
+
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/events:
+    get:
+      tags:
+        - Documents > Document Events
+      summary: Retrieve Document Events
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Events
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/objects/documents/templates:
+    get:
+      tags:
+        - Documents > Document Templates
+      summary: Retrieve Document Template Metadata
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Template_Metadata
+
+
+
+        Retrieve the metadata which defines the shape of document templates in
+        your Vault.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/templates:
+    get:
+      tags:
+        - Documents > Document Templates
+      summary: Retrieve Document Template Collection
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Template_Collection
+
+
+
+        Retrieve all document templates.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Documents > Document Templates
+      summary: Create Multiple Document Templates
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Bulk_Create_Document_Templates
+
+
+
+        Create up to 500 document templates.
+
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - Documents > Document Templates
+      summary: Update Multiple Document Templates
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Bulk_Update_Document_Templates
+
+
+
+        Update up to 500 document templates in your Vault.
+
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/templates/:{template_name}:
+    get:
+      tags:
+        - Documents > Document Templates
+      summary: Retrieve Document Template Attributes
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Template_Attributes
+
+
+
+        Retrieve the attributes from a document template.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: template_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - Documents > Document Templates
+      summary: Update Single Document Template
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Update_Document_Template
+
+
+        Update a single document template in your Vault.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: template_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Documents > Document Templates
+      summary: Delete Basic Document Template
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Delete_Document_Template
+
+
+
+        Delete a basic document template from your Vault. You cannot delete
+        controlled document templates. Learn more about <a
+        href="https://platform.veevavault.help/en/lr/46018#deleting-controlled-document-templates">controlled
+        template deletion in Vault Help</a>.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: template_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/templates/:{template_name}/file:
+    get:
+      tags:
+        - Documents > Document Templates
+      summary: Download Document Template File
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Download_Document_Template_File
+
+
+
+        Download the file of a specific document template.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: template_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/query/documents/relationships/document_signature__sysr:
+    get:
+      tags:
+        - Documents > Document Signatures
+      summary: Retrieve Document Signature Metadata
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Signature_Metadata
+
+
+
+        Retrieve all metadata for signatures on documents. Learn more about <a
+        href="https://platform.veevavault.help/en/lr/40560/">signature pages in
+        Vault Help.</a>
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/query/archived_documents/relationships/document_signature__sysr:
+    get:
+      tags:
+        - Documents > Document Signatures
+      summary: Retrieve Archived Document Signature Metadata
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Archived_Document_Signature_Metadata
+
+
+
+        Retrieve all metadata for signatures on archived documents. Learn more
+        about <a href="https://platform.veevavault.help/en/lr/40560/">signature
+        pages in Vault Help.</a>
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/tokens:
+    post:
+      tags:
+        - Documents
+      summary: Document Tokens
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Vault_Document_Tokens
+
+
+
+        The Vault Document Tokens API allows you to generates document access
+        tokens needed by the external viewer to view documents outside of Vault.
+        <a
+        href="http://developer.veevavault.com/docs/vault-document-external-viewer/">Learn
+        more.</a>
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/:{binder_id}:
+    get:
+      tags:
+        - Binders > Retrieve Binders
+      summary: Retrieve Binder
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Binder
+
+
+
+        * Use this endpoint to retrieve all fields and values configured on a
+        specific binder in you Vault (using the binder ID).
+
+        * The response includes the "first level" of the binder section node
+        structure.
+
+        * To retrieve additional levels in the binder section node structure,
+        use one of the `depth` parameters described below.
+
+        * For binders with unbound documents, the response includes versions
+        based on binder display options for unbound documents set in the UI.
+        Learn more about Document Type Settings in <a
+        href="https://platform.veevavault.help/en/lr/618">Vault Help</a>.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: depth
+          in: query
+          schema:
+            type: string
+          description: >-
+            To retrieve all information in all levels of the binder, set this to
+            all. By default, only one level is returned.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Binders > Create Binders
+      summary: Create Binder Version
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Create_Binder_Version
+
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - Binders > Update Binders
+      summary: Reclassify Binder
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Reclassify_Binder
+
+
+
+        Reclassify allows you to change the document type of an existing binder.
+        A document "type" is the combination of the `type__v`, `subtype__v`, and
+        `classification__v` fields on a binder. When you reclassify, Vault may
+        add or remove certain fields on the binder. You can only reclassify the
+        latest version of a binder and only one binder at a time. The API does
+        not currently support Bulk Reclassify.
+
+
+        Learn more about:
+
+
+        * Vault Help: <a
+        href="https://platform.veevavault.help/en/lr/2271">Reclassifying
+        Documents</a>.
+
+        * API: <a
+        href="https://developer.veevavault.com/api/24.3#Vault_Retrieve_Binders_API_Reference">Retrieve
+        Binders</a>
+
+        * API: <a
+        href="https://developer.veevavault.com/api/24.3#Retrieve_All_Document_Fields">Retrieve
+        Document Fields</a>
+
+        * API: <a
+        href="https://developer.veevavault.com/api/24.3#Retrieve_All_Document_Types">Retrieve
+        Document Types, Subtypes, and Classifications</a>
+
+
+        #### About this Request
+
+
+        * You can only reclassify the latest version of a specified binder.
+
+        * You can only reclassify one binder at a time. Bulk reclassify is not
+        currently supported.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Binders > Delete Binders
+      summary: Delete Binder
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Delete_Binder
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/:{binder_id}/versions:
+    get:
+      tags:
+        - Binders > Retrieve Binders
+      summary: Retrieve All Binder Versions
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Retrieve_All_Binder_Versions
+
+
+        Retrieve all versions of a binder.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/:{binder_id}/versions/:{major_version}/:{minor_version}:
+    get:
+      tags:
+        - Binders > Retrieve Binders
+      summary: Retrieve Binder Version
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Retrieve_Binder_Version](https://developer.veevavault.com/api/25.1/#Retrieve_Binder_Version)
+
+
+        Retrieve the fields and values configured on a specific version of a
+        specific binder.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - Binders > Update Binders
+      summary: Update Binder Version
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Update_Binder_Version
+
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Binders > Delete Binders
+      summary: Delete Binder Version
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Delete_Binder_Version
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders:
+    post:
+      tags:
+        - Binders > Create Binders
+      summary: Create Binder from Template
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Create_Binder_from_Template
+
+
+        Since we’re creating a new binder with the document type “Compliance
+        Package” and subtype “Professional”, we need to find the available
+        templates in the type/subtype metadata:
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/:{binder_id}/actions:
+    post:
+      tags:
+        - Binders > Update Binders
+      summary: Refresh Binder Auto-Filing
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Refresh_Binder_AutoFiling
+
+
+
+        <aside class="label">This is only available in eTMF Vaults on binders
+        configured with the TMF Reference Models.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/:{binder_id}/actions/export:
+    post:
+      tags:
+        - Binders > Export Binders
+      summary: Export Binder Sections (Latest Version)
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Export_Binder_Sections
+
+
+        Use this request to export only specific sections and documents from the
+        latest version of a binder in your Vault. This will export only parts of
+        the binder, not the complete binder.
+
+
+        Before submitting this request:
+
+
+        * The Export Binder feature must be enabled in your Vault.
+
+        * You must be assigned permissions to use the API.
+
+        * You must have the Export Binder permission.
+
+        * You must have the View Document permission for the binder.
+
+        * Only documents in the binder which you have the View Document
+        permission are available to export.
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: depth
+          in: query
+          schema:
+            type: string
+          example: all
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/:{binder_id}/versions/:{major_version}/:{minor_version}/actions/export:
+    post:
+      tags:
+        - Binders > Export Binders
+      summary: Export Binder Sections (Specific Version)
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Export_Binder_Sections
+
+
+        Use this request to export only specific sections and documents from a
+        specific version of a binder in your Vault. This will export only parts
+        of the binder, not the complete binder.
+
+
+        Before submitting this request:
+
+
+        * The Export Binder feature must be enabled in your Vault.
+
+        * You must be assigned permissions to use the API.
+
+        * You must have the Export Binder permission.
+
+        * You must have the View Document permission for the binder.
+
+        * Only documents in the binder which you have the View Document
+        permission are available to export.
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: depth
+          in: query
+          schema:
+            type: string
+          example: all
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/actions/export/:{job_id}/results:
+    get:
+      tags:
+        - Binders > Export Binders
+      summary: Retrieve Binder Export Results
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Retrieve_Binder_Export_Results
+
+
+        After submitting a request to export a binder from your Vault, you can
+        query Vault to determine the results of the request.
+
+
+        Before submitting this request:
+
+
+        * You must have previously requested a binder export job (via the API)
+        which is no longer active.
+
+        * You must have a valid `job_id` value (retrieved from the export binder
+        request above).
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: job_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/:{binder_id}/versions/:{major_version}/:{minor_version}/relationships/:{relationship_id}:
+    get:
+      tags:
+        - Binders > Binder Relationships
+      summary: Retrieve Binder Relationship
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Binder_Relationship
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: relationship_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Binders > Binder Relationships
+      summary: Delete Binder Relationship
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Delete_Binder_Relationship
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: relationship_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/:{binder_id}/versions/:{major_version}/:{minor_version}/relationships:
+    post:
+      tags:
+        - Binders > Binder Relationships
+      summary: Create Binder Relationship
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Create_Binder_Relationship
+
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/:{binder_id}/sections/:{section_id}:
+    get:
+      tags:
+        - Binders > Binder Sections
+      summary: Retrieve Binder Sections
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Binder_Sections
+
+
+
+        Retrieve all sections (documents and subsections) in a binder's
+        top-level root node or sub-level node.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: section_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Binders > Binder Sections
+      summary: Delete Binder Section
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Delete_Binder_Section
+
+
+        Delete a section from a binder.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: section_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/:{binder_id}/versions/:{major_version}/:{minor_version}/sections/:{section_id}:
+    get:
+      tags:
+        - Binders > Binder Sections
+      summary: Retrieve Binder Version Section
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Binder_Version_Section
+
+
+
+        For a specific version, retrieve all sections (documents and subsection)
+        in a binder's top-level root node or sub-level node.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: section_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/:{binder_id}/sections:
+    post:
+      tags:
+        - Binders > Binder Sections
+      summary: Create Binder Section
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Create_Binder_Section
+
+
+        Create a new section in a binder.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/:{binder_id}/sections/:{node_id}:
+    put:
+      tags:
+        - Binders > Binder Sections
+      summary: Update Binder Section
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Update_Binder_Section
+
+
+        Update a section in a binder.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: node_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/:{binder_id}/documents:
+    post:
+      tags:
+        - Binders > Binder Documents
+      summary: Add Document to Binder
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Add_Document_to_Binder
+
+
+        Add a document to a binder.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/:{binder_id}/documents/:{section_id}:
+    put:
+      tags:
+        - Binders > Binder Documents
+      summary: Move Document in Binder
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Move_Document_in_Binder
+
+
+        Move a document to a different position within a binder.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: section_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Binders > Binder Documents
+      summary: Remove Document from Binder
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Remove_Document_from_Binder
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: section_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/objects/binders/templates:
+    get:
+      tags:
+        - Binders > Binder Templates
+      summary: Retrieve Binder Template Metadata
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Binder_Template_Metadata
+
+
+
+        Retrieve the metadata which defines the shape of binder templates in
+        your Vault.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/objects/binders/templates/bindernodes:
+    get:
+      tags:
+        - Binders > Binder Templates
+      summary: Retrieve Binder Template Node Metadata
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Binder_Template_Node_Metadata
+
+
+
+        Retrieve the metadata which defines the shape of binder template nodes
+        in your Vault.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/templates:
+    get:
+      tags:
+        - Binders > Binder Templates
+      summary: Retrieve Binder Template Collection
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Binder_Template_Collection
+
+
+
+        Retrieve the collection of all binder templates in your Vault.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Binders > Binder Templates
+      summary: Bulk Create Binder Templates
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Bulk_Create_Binder_Templates
+
+
+        Create from 1-500 new binder templates in your Vault.
+
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - Binders > Binder Templates
+      summary: Bulk Update Binder Templates
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Bulk_Update_Binder_Templates
+
+
+
+        Update from 1-500 binder templates in your Vault.
+
+
+        By changing the document type/subtype/classification, you can move an
+        existing binder template to a different level of the document type
+        hierarchy, effectively reclassifying the template.
+
+
+        See also: **Update [Single] Binder Template** <a
+        href="https://developer.veevavault.com/api/24.3#Update_Binder_Template">above</a>.
+
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/templates/:{template_name}:
+    get:
+      tags:
+        - Binders > Binder Templates
+      summary: Retrieve Binder Template Attributes
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Binder_Template_Attributes
+
+
+
+        Retrieve the attributes of a specific binder template in your Vault.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: template_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Binders > Binder Templates
+      summary: Delete Binder Template
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Delete_Binder_Template
+
+
+        Delete an existing binder template from your Vault.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: template_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/templates/:{template_name}/bindernodes:
+    get:
+      tags:
+        - Binders > Binder Templates
+      summary: Retrieve Binder Template Node Attributes
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Binder_Template_Node_Attributes
+
+
+        Retrieve the attributes of each node (folder/section) of a specific
+        binder template in your Vault.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: template_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Binders > Binder Templates
+      summary: Create Binder Template Node
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Create_Binder_Template_Node
+
+
+        Create nodes in an existing binder template.
+
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: template_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - Binders > Binder Templates
+      summary: Replace Binder Template Nodes
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Replace_Binder_Template_Nodes
+
+
+
+        Replace all binder nodes in an existing binder template. This action
+        removes all existing nodes and replaces them with those specified in the
+        input.
+
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: template_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/:{binder_id}/binding_rule:
+    put:
+      tags:
+        - Binders > Binding Rules
+      summary: Update Binding Rule
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Update_Binding_Rule
+
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/:{binder_id}/sections/:{node_id}/binding_rule:
+    put:
+      tags:
+        - Binders > Binding Rules
+      summary: Update Binder Section Binding Rule
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Update_Binder_Section_Binding_Rule
+
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: node_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/:{binder_id}/documents/:{node_id}/binding_rule:
+    put:
+      tags:
+        - Binders > Binding Rules
+      summary: Update Binder Document Binding Rule
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Update_Binder_Document_Binding_Rule
+
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: node_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/configuration/Objecttype:
+    get:
+      tags:
+        - Vault Objects > Object Types
+      summary: Retrieve Details from All Object Types
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Details_All_Object_Types
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/configuration/:{object_name_and_object_type}:
+    get:
+      tags:
+        - Vault Objects > Object Types
+      summary: Retrieve Details from a Specific Object
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Details_Specific_Object
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: loc
+          in: query
+          schema:
+            type: string
+          description: >-
+            When localized (translated) strings are available, retrieve them by
+            setting loc to true.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name_and_object_type
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/:{object_name}/actions/changetype:
+    post:
+      tags:
+        - Vault Objects > Object Types
+      summary: Change Object Type
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Change_Object_Type
+
+
+
+        Change the object types assigned to object records. Any field values
+        which exist on both the original and new object type will carry over to
+        the new type. All other field values will be removed, as only fields on
+        the new type are valid. You can set field values on the new object type
+        in the CSV input.
+
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/:{object_name}/:{id}/roles/:{role_name}:
+    get:
+      tags:
+        - Vault Objects > Object Roles
+      summary: Retrieve Object Record Roles
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Object_Roles
+
+
+
+        Retrieve manually assigned roles on an object record and the users and
+        groups assigned to them.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: role_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/:{object_name}/roles:
+    post:
+      tags:
+        - Vault Objects > Object Roles
+      summary: Assign Users & Groups to Roles on Object Records
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Assign_Users_Groups_to_Roles_Objects
+
+
+
+        Assign users and groups to roles on an object record in bulk.
+
+
+        * The maximum CSV input file size is 1GB.
+
+        * The values in the input must be UTF-8 encoded.
+
+        * CSVs must follow the <a
+        href="https://datatracker.ietf.org/doc/html/rfc4180">standard
+        format.</a>
+
+        * The maximum batch size is 500.
+
+
+        Assigning users and groups to roles is additive, and duplicate groups
+        are ignored. For example, if groups 1 and 2 are currently assigned to a
+        particular role and you assign groups 2 and 3 to the same role, the
+        final list of groups assigned to the role will be 1, 2, and 3.
+
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Vault Objects > Object Roles
+      summary: Remove Users & Groups from Roles on Object Records
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Remove_Users_Groups_Roles_Objects
+
+
+
+        Remove users and groups from roles on an object record in bulk.
+
+
+        * The maximum CSV input file size is 1GB.
+
+        * The values in the input must be UTF-8 encoded.
+
+        * CSVs must follow the <a href
+        ="https://datatracker.ietf.org/doc/html/rfc4180">standard format.</a>
+
+        * The maximum batch size is 500.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/vobjects/:{object_name}:
+    get:
+      tags:
+        - Vault Objects > Object Record Attachments
+      summary: Determine if Attachments are Enabled on an Object
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Determine_if_Attachments_are_Enabled_on_an_Object
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/:{object_name}/:{object_record_id}/attachments:
+    get:
+      tags:
+        - Vault Objects > Object Record Attachments
+      summary: Retrieve Object Record Attachments
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Object_Record_Attachments
+
+
+
+        Retrieve a list of all attachments on a specific object record.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_record_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Vault Objects > Object Record Attachments
+      summary: Create Object Record Attachment
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Create_Object_Record_Attachment
+
+
+
+        Create a single object record attachment. If the attachment already
+        exists, Vault uploads the attachment as a new version of the existing
+        attachment. Learn more about <a
+        href="https://platform.veevavault.help/en/lr/24287#version-specific">attachment
+        versioning in Vault Help</a>.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_record_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/:{object_name}/:{object_record_id}/attachments/:{attachment_id}:
+    get:
+      tags:
+        - Vault Objects > Object Record Attachments
+      summary: Retrieve Object Record Attachment Metadata
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Object_Record_Attachment_Metadata
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_record_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - Vault Objects > Object Record Attachments
+      summary: Update Object Record Attachment Description
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Update_Object_Record_Attachment_Description
+
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_record_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Vault Objects > Object Record Attachments
+      summary: Delete Object Record Attachment
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Delete_Object_Record_Attachment
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_record_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/:{object_name}/:{object_record_id}/attachments/:{attachment_id}/versions:
+    get:
+      tags:
+        - Vault Objects > Object Record Attachments
+      summary: Retrieve Object Record Attachment Versions
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Object_Record_Attachment_Versions
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_record_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/:{object_name}/:{object_record_id}/attachments/:{attachment_id}/versions/:{attachment_version}:
+    get:
+      tags:
+        - Vault Objects > Object Record Attachments
+      summary: Retrieve Object Record Attachment Version Metadata
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Object_Record_Attachment_Version_Metadata
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_record_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Vault Objects > Object Record Attachments
+      summary: Restore Object Record Attachment Version
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Restore_Object_Record_Attachment_Version
+
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: restore
+          in: query
+          schema:
+            type: boolean
+          example: 'true'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_record_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Vault Objects > Object Record Attachments
+      summary: Delete Object Record Attachment Version
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Delete_Object_Record_Attachment_Version
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_record_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/:{object_name}/:{object_record_id}/attachments/:{attachment_id}/versions/:{attachment_version}/file:
+    get:
+      tags:
+        - Vault Objects > Object Record Attachments
+      summary: Download Object Record Attachment Version File
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Download_Object_Record_Attachment_Version_File
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_record_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/:{object_name}/:{object_record_id}/attachments/file:
+    get:
+      tags:
+        - Vault Objects > Object Record Attachments
+      summary: Download All Object Record Attachment Files
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Download_All_Object_Record_Attachment_Files
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_record_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/:{object_name}/attachments/batch:
+    post:
+      tags:
+        - Vault Objects > Object Record Attachments
+      summary: Create Multiple Object Record Attachments
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Create_Multiple_Object_Record_Attachments
+
+
+
+        You can create object record attachments in bulk with a JSON or CSV
+        input file. You must first load the attachments to the <a
+        href="https://developer.veevavault.com/docs/#FTP">file staging
+        server</a>. If the attachment already exists in your Vault, Vault
+        uploads it as a new version of the existing attachment. Learn more about
+        <a
+        href="https://platform.veevavault.help/en/lr/24287#version-specific">attachment
+        versioning in Vault Help</a>.
+
+
+        * The maximum input file size is 1GB.
+
+        * The values in the input must be UTF-8 encoded.
+
+        * CSVs must follow the <a
+        href="https://datatracker.ietf.org/doc/html/rfc4180">standard
+        format</a>.
+
+        * The maximum batch size is 500.
+
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - Vault Objects > Object Record Attachments
+      summary: Update Multiple Object Record Attachment Descriptions
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Update_Multiple_Object_Record_Attachment_Descriptions
+
+
+
+        Update object record attachments in bulk with a JSON or CSV input file.
+        You can only update the latest version of an attachment.
+
+
+        * The maximum input file size is 1GB.
+
+        * The values in the input must be UTF-8 encoded.
+
+        * CSVs must follow the <a
+        href="https://datatracker.ietf.org/doc/html/rfc4180">standard
+        format</a>.
+
+        * The maximum batch size is 500.
+
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Vault Objects > Object Record Attachments
+      summary: Delete Multiple Object Record Attachments
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Delete_Multiple_Object_Record_Attachments
+
+
+
+        Delete object record attachments in bulk with a JSON or CSV input file.
+        You can only delete the latest version of an attachment.
+
+
+        * The maximum input file size is 1GB.
+
+        * The values in the input must be UTF-8 encoded.
+
+        * CSVs must follow the <a
+        href="https://datatracker.ietf.org/doc/html/rfc4180">standard
+        format</a>.
+
+        * The maximum batch size is 500.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: idParam
+          in: query
+          schema:
+            type: string
+          example: >-
+            If you’re identifying attachments in your input by external id, add
+            idParam=external_id__v to the request endpoint.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/vobjects/:object_name/page_layouts:
+    get:
+      tags:
+        - Vault Objects > Object Page Layouts
+      summary: Retrieve Page Layouts
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Page_Layouts
+
+
+
+        Given an object, retrieve all page layouts associated with that object.
+        You can use this data to <a
+        href="https://developer.veevavault.com/api/24.3#Retrieve_Page_Layout_Metadata">retrieve
+        specific page layout metadata</a>.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/vobjects/:object_name/page_layouts/:layout_name:
+    get:
+      tags:
+        - Vault Objects > Object Page Layouts
+      summary: Retrieve Page Layout Metadata
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Retrieve_Page_Layout_Metadata](https://developer.veevavault.com/api/25.1/#Retrieve_Page_Layout_Metadata)
+
+
+        Given a page layout `name`, retrieve the metadata for that specific page
+        layout.
+
+
+        The page layout APIs consider the authenticated user’s permissions, so
+        fields that are hidden from the authenticated user will not be included
+        in the API response. For example, field-level security, object controls,
+        and other object-level permissions are considered. Record-level
+        permissions such as atomic security are not considered. Both active and
+        inactive fields are included in the response.
+
+
+        This endpoint returns metadata without layout rules applied, instead
+        returning layout rule configurations as metadata. If a layout rule
+        references the currently authenticated user, this endpoint returns the
+        `@User` token instead of resolving it to the value of the authenticated
+        user.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/:{object_name}/actions/merge:
+    post:
+      tags:
+        - Vault Objects > Merge Object Records
+      summary: Initiate Record Merge
+      description: >-
+        Initiate a record merge operation in bulk. Starts a record merge job.
+
+
+        When merging two records together, you must select one record to be the
+        `main_record_id` and one record to be the `duplicate_record_id`. The
+        merging process updates all inbound references (including attachments)
+        from other objects that point to the `duplicate_record_id` and moves
+        those over to the `main_record_id`. Field values on the`main_record_id`
+        are not changed, and when the process is complete, Vault deletes the
+        `duplicate_record_id`. Record merges do not trigger [record
+        triggers](https://developer.veevavault.com/sdk/#About_Record_Triggers).
+
+
+        You can only merge two records together in a single operation, one
+        `main_record_id` and one `duplicate_record_id`. This is called a merge
+        set.
+
+
+        If you have multiple `duplicate_record_id`s you wish to merge into the
+        same`main_record_id`, you need to create multiple merge sets and execute
+        multiple record merges.
+
+
+        - The values in the input must be UTF-8 encoded.
+            
+        - CSVs must follow the standard RFC 4180 format, with some
+        [exceptions](https://developer.veevavault.com/docs/#CSV_RFC_Deviations).
+            
+        - The maximum batch size is 10 merge sets.
+            
+
+        The object must have **Enable Merges** configured, and the initiating
+        user must have the correct permissions such as the _Application: Object:
+        Merge Records_ permission. Learn more about the [configuration required
+        for record merges in Vault
+        Help](https://platform.veevavault.help/en/lr/659058).
+
+
+        In Clinical Operations Vaults, this endpoint does not support merging
+        _Person_ (`person__sys`), _Organization_ (`organization__v`), _Location_
+        (`location__v`), or _Contact Information_ (`contact_information__clin`)
+        records. Instead, use [Initiate Clinical Record
+        Merge](https://developer.veevavault.com/api/25.1/#Initiate_Clinical_Record_Merge).
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                - duplicate_record_id: 0V0000000003
+                  main_record_id: 0V0000000013
+                - duplicate_record_id: 0V0000000004
+                  main_record_id: 0V0000000013
+                - duplicate_record_id: 0V0000000005
+                  main_record_id: 0V0000000010
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/merges/:{job_id}/status:
+    get:
+      tags:
+        - Vault Objects > Merge Object Records
+      summary: Retrieve Record Merge Status
+      description: >-
+        Given a `job_id` for a merge records job, retrieve the job status.
+
+
+        Before submitting this request:
+
+
+        - You must have previously requested a record merge job
+
+        - You must have a valid `job_id` field value returned from the record
+        merge operation
+            
+
+        ### Response
+
+
+        On `SUCCESS`, the merge job may have one of the following `status`:
+
+
+        - `IN_PROGRESS`: The job is currently running
+
+        - `SUCCESS`: The job completed with no errors; all records were merged
+
+        - `FAILURE`: The job completed with errors; one or more records were not
+        merged
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: job_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/merges/:{job_id}/results:
+    get:
+      tags:
+        - Vault Objects > Merge Object Records
+      summary: Retrieve Record Merge Results
+      description: >-
+        Given a `job_id` for a merge records job, retrieve the job results.
+
+
+        Before submitting this request:
+
+
+        - You must have previously requested a record merge job which is no
+        longer `IN_PROGRESS`
+            
+        - You must have a valid `job_id` field value returned from the record
+        merge operation
+            
+
+        ## Response
+
+
+        The response contains a JSON object with the following structure:
+
+
+        ``` json
+
+        {
+            "responseStatus": "",
+            "data": {
+                "merge_sets": [
+                    {
+                        "duplicate_record_id": "",
+                        "main_record_id": "",
+                        "status": "",
+                        "error": {
+                            "type": "",
+                            "message": ""
+                        }
+                    }
+                ]
+            }
+        }
+
+         ```
+
+        - `responseStatus` (string): The status of the response.
+
+        - `merge_sets` (array): An array of merge sets, each containing the
+        following properties:
+            - `duplicate_record_id` (string): The ID of the duplicate record.
+            - `main_record_id` (string): The ID of the main record.
+            - `status` (string): The status of the merge operation.
+                - `INVALID_DATA`: The merge was not attempted
+                - `PROCESSING_ERROR`: The merge was attempted, but failed during processing
+            - `error` (object): An object containing error details, with the following properties:
+                - `type` (string): The type of error.
+                - `message` (string): The error message.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: job_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/merges/:{job_id}/log:
+    get:
+      tags:
+        - Vault Objects > Merge Object Records
+      summary: Download Merge Records Job Log
+      description: >-
+        Given a `job_id` for a merge records job, retrieve the job history log.
+        The same log is available for download through the Vault UI from **Admin
+        > Operations > Job Status**.
+
+
+        Before submitting this request:
+
+
+        - You must have previously requested a record merge job which is no
+        longer `IN_PROGRESS`
+
+        - You must have a valid `job_id` field value returned from the record
+        merge operation
+            
+
+        ## Response
+
+
+        On SUCCESS, Vault downloads the job history log for the specified merge
+        record job. The HTTP Response Header `Content-Type` is set to
+        `application/zip`. The HTTP Response Header `Content-Disposition`
+        contains a default filename component which you can use when naming the
+        local file. If you choose to name this file yourself, make sure you add
+        the `.zip` extension.
+
+
+        The merge record job history log contains information about the merge,
+        such as the merge start and completion times, relationship processing
+        start and end times, attachment processing start and end times, and
+        more.
+
+
+        ``` bash
+
+        2024-03-01T00:50:01.741Z Started processing merge records job [873101]
+
+        2024-03-01T00:50:02.116Z Merge sets [Duplicate Record:[OBE000000006005],
+        Main Record:[OBE00000000D002];Duplicate Record:[OBE000000008004], Main
+        Record:[OBE00000000D002];Duplicate Record:[OBE000000000201], Main
+        Record:[OBE00000000D002]] passed validation and will be merged in job
+        [873101]
+
+        2024-03-01T00:50:02.116Z Starting distributed work for merge records job
+        [873101]
+
+        2024-03-01T00:50:02.632Z Began processing [INBOUND_CHILD_OBJECT]
+        relationship configured on Object [campaign_country_join__c] field
+        [campaign__c] for job [873101]. [0] record(s) will be processed
+
+        2024-03-01T00:50:02.640Z Finished processing [INBOUND_CHILD_OBJECT]
+        relationship for job [873101]
+
+        2024-03-01T00:50:02.924Z Began processing [INBOUND_OBJECT] relationship
+        configured on Object [review_meeting__c] field [related_campaign__c] for
+        job [873101]. [0] record(s) will be processed
+
+        2024-03-01T00:50:02.932Z Finished processing [INBOUND_OBJECT]
+        relationship for job [873101]
+
+        2024-03-01T00:50:02.957Z Began processing [INBOUND_DOCUMENT]
+        relationship configured on Document field [related_campaigns__c] for job
+        [873101]. [0] document(s) will be processed
+
+        2024-03-01T00:50:02.964Z Finished processing [INBOUND_DOCUMENT]
+        relationship for job [873101]
+
+        2024-03-01T00:50:02.965Z Starting to move attachments for job [873101]
+
+        2024-03-01T00:50:03.013Z Finished moving attachments for job [873101]
+
+        2024-03-01T00:50:03.197Z Completed merge records job [873101]
+
+        2024-03-01T00:50:03.197Z Merge Records job [873101] successfully merged
+        Merge Sets: [Duplicate Record:[OBE000000006005], Main
+        Record:[OBE00000000D002];Duplicate Record:[OBE000000008004], Main
+        Record:[OBE00000000D002];Duplicate Record:[OBE000000000201], Main
+        Record:[OBE00000000D002]] 
+
+        2024-03-01T00:50:03.206Z 
+
+        2024-03-01T00:50:03.207Z Job Title: AsyncOperation
+
+        2024-03-01T00:50:03.207Z Job Type: ASYNC_OPERATION
+
+        2024-03-01T00:50:03.207Z Job Subtype: MERGE_RECORDS_JOB
+
+        2024-03-01T00:50:03.207Z Job Schedule Time: 2024-03-01T00:50:02.000Z
+
+        2024-03-01T00:50:03.207Z Job Queue Time: 2024-03-01T00:50:02.000Z
+
+        2024-03-01T00:50:03.207Z Job Execution Time: 2024-03-01T00:50:02.000Z
+
+         ```
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: job_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/:{object_name}/:{object_record_id}/attachment_fields/:{attachment_field_name}/file:
+    get:
+      tags:
+        - Vault Objects > Attachment Fields
+      summary: Download Attachment Field File
+      description: Download the specified _Attachment_ field file from an object record.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_record_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_field_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Vault Objects > Attachment Fields
+      summary: Update Attachment Field File
+      description: >-
+        Update an _Attachment_ field by uploading a file. If you need to update
+        more than one _Attachment_ field, it is best practice to update in bulk
+        with Update Object Records.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_record_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: attachment_field_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/:{object_name}/:{object_record_id}/attachment_fields/file:
+    get:
+      tags:
+        - Vault Objects > Attachment Fields
+      summary: Download All Attachment Field Files
+      description: Download all _Attachment_ field files from the specified object record.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_record_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/:{object_name}/actions/recalculaterollups:
+    post:
+      tags:
+        - Vault Objects > Roll-up Fields
+      summary: Recalculate Roll-up Fields
+      description: >-
+        Recalculate all Roll-up fields for the specified object. <a
+        href="https://platform.veevavault.help/en/lr/15057/#roll-up-fields">Learn
+        more about Roll-up field calculation in Vault Help</a>.
+
+
+        When performing a full recalculation, Vault evaluates all Roll-up fields
+        on an object asynchronously.
+
+
+        This endpoint is equivalent to the _Recalculate Roll-up Fields_ action
+        in the Vault UI. While a recalculation is running, Admins cannot start
+        another recalculation using either the Vault REST API or Vault UI.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    get:
+      tags:
+        - Vault Objects > Roll-up Fields
+      summary: Retrieve Roll-up Field Recalculation Status
+      description: >-
+        Determine whether a Roll-up field recalculation is currently running. <a
+        href="https://platform.veevavault.help/en/lr/15057/#roll-up-fields">Learn
+        more about Roll-up fields in Vault Help</a>.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/vobjects/:object_name:
+    get:
+      tags:
+        - Vault Objects
+      summary: Retrieve Object Metadata
+      description: |-
+        https://developer.veevavault.com/api/25.1/#Retrieve_Object_Metadata
+
+        Retrieve all metadata configured on a standard or custom Vault Object.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: loc
+          in: query
+          schema:
+            type: boolean
+          description: >-
+            To retrieve localized (translated) strings, include the parameter
+            loc=true. See the next request below for details.
+          example: 'true'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/vobjects/:object_name/fields/:object_field_name:
+    get:
+      tags:
+        - Vault Objects
+      summary: Retrieve Object Field Metadata
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Retrieve_Object_Field_Metadata
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: loc
+          in: query
+          schema:
+            type: boolean
+          description: >-
+            To retrieve localized (translated) strings, include the parameter
+            loc=true. See the next request below for details.
+          example: 'true'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/vobjects:
+    get:
+      tags:
+        - Vault Objects
+      summary: Retrieve Object Collection
+      description: |-
+        https://developer.veevavault.com/api/25.1/#Retrieve_Object_Collection
+
+        Retrieve all Vault objects in the authenticated Vault.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: loc
+          in: query
+          schema:
+            type: boolean
+          description: >-
+            To retrieve localized (translated) strings, include the parameter
+            loc=true. See the next request below for details.
+          example: 'true'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/:object_name:
+    get:
+      tags:
+        - Vault Objects
+      summary: Retrieve Object Record Collection
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Retrieve_Object_Record_Collection
+
+
+        Retrieve all records for a specific Vault Object.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: fields
+          in: query
+          schema:
+            type: string
+          description: >-
+            To specify fields to retrieve, include the parameter
+            fields={FIELD_NAMES}. See the next request below for details.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/:{object_name}/:{object_record_id}:
+    get:
+      tags:
+        - Vault Objects
+      summary: Retrieve Object Record
+      description: |-
+        https://developer.veevavault.com/api/25.1/#Retrieve_Object_Record
+
+        Retrieve metadata configured on a specific object record in your vault.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_record_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/:{object_name}:
+    post:
+      tags:
+        - Vault Objects
+      summary: Create & Upsert Object Records
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Create_Object_Record](https://developer.veevavault.com/api/25.1/#Create_Object_Record)
+
+
+        Create or
+        [upsert](https://developer.veevavault.com/api/25.1/#Query_String_Parameters_Upsert_Object_Records)
+        Vault object records in bulk.
+
+
+        You can use this endpoint to create User Tasks or [User
+        (<code>user__sys</code>)
+        records](https://developer.veevavault.com/api/25.1/#Create_User_Object_Record).
+
+
+        - The maximum input file size is 1GB.
+            
+        - The values in the input must be UTF-8 encoded.
+            
+        - CSVs must follow the [standard
+        format](https://datatracker.ietf.org/doc/html/rfc4180), with some
+        [exceptions](https://developer.veevavault.com/docs/#CSV_RFC_Deviations).
+            
+        - The maximum batch size is 500.
+            
+
+        Note that you can only add [relationships on object
+        fields](https://developer.veevavault.com/api/25.1/#Add_Relationships_on_Object_Fields)
+        using ID values or based on a unique field on the target object. This
+        API does not support [object lookup
+        fields](https://developer.veevavault.com/vql/#Object_Lookup_Fields).
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          description: Can be text/csv or application/json
+          example: text/csv
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          description: Can be text/csv or application/json
+          example: application/json
+        - name: X-VaultAPI-MigrationMode
+          in: header
+          schema:
+            type: boolean
+          description: >-
+            If set to `true`, Vault allows you to create or update object
+            records in a noninitial state and with minimal validation, create
+            inactive records, and set standard and system-managed fields such as
+            `created_by__v`. Does not bypass record triggers. Use the
+            `X-VaultAPI-NoTriggers` header to bypass all standard and custom SDK
+            triggers. You must have the Record Migration permission to use this
+            header.
+          example: 'true'
+        - name: X-VaultAPI-NoTriggers
+          in: header
+          schema:
+            type: boolean
+          description: >-
+            If set to `true` and Record Migration Mode is enabled, it bypasses
+            all standard and custom SDK triggers.
+          example: 'true'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: idParam
+          in: query
+          schema:
+            type: string
+          description: >-
+            To upsert object records, add `idParam={field_name}` to the request
+            endpoint. You can use any object field which has `unique` set to
+            `true` in the object metadata. For example,
+            `idParam=external_id__v`.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - Vault Objects
+      summary: Update Object Records
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Update_Object_Records
+
+
+        Update Object Records in bulk. You can use this endpoint to update user
+        records (`user__sys`).
+
+
+        * The maximum input file size is 1GB.
+
+        * The values in the input must be UTF-8 encoded.
+
+        * CSVs must follow the <a
+        href="https://datatracker.ietf.org/doc/html/rfc4180">standard
+        format.</a>
+
+        * The maximum batch size is 500.
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          description: Can be text/csv or application/json
+          example: text/csv
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          description: Can be text/csv or application/json
+          example: application/json
+        - name: X-VaultAPI-MigrationMode
+          in: header
+          schema:
+            type: boolean
+          description: >-
+            If set to `true`, Vault allows you to update object records in a
+            noninitial state and with minimal validation, create inactive
+            records, and set standard and system-managed fields such as
+            `created_by__v`. Does not bypass record triggers. Use the
+            `X-VaultAPI-NoTriggers` header to bypass all standard and custom SDK
+            triggers. You must have the Record Migration permission to use this
+            header.
+          example: 'true'
+        - name: X-VaultAPI-NoTriggers
+          in: header
+          schema:
+            type: boolean
+          description: >-
+            If set to `true` and Record Migration Mode is enabled, it bypasses
+            all standard and custom SDK triggers.
+          example: 'true'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Vault Objects
+      summary: Delete Object Records
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Delete_Object_Record
+
+
+        Delete Object Records in bulk. Admins can also define special deletion
+        rules for objects, which affects how Vault behaves when you attempt to
+        delete an object record. Learn more about <a
+        href="https://platform.veevavault.help/en/lr/18769#relationships_deletion">limitations
+        on object record deletion in Vault Help</a>.
+
+
+        If you need to delete a parent record along with all of its children and
+        grandchildren, use the <a
+        href="https://developer.veevavault.com/api/25.1/#Cascade_Delete_Object_Record">Cascade
+        Delete</a> endpoint.
+
+
+        Note that you cannot use this API to delete `user__sys` records. Use the
+        <a
+        href="https://developer.veevavault.com/api/25.1/#Update_Object_Records">Update
+        Object Records</a> endpoint to set the `status__v` field to `inactive`.
+
+
+        * The maximum input file size is 1GB.
+
+        * The values in the input must be UTF-8 encoded.
+
+        * CSVs must follow the <a
+        href="https://datatracker.ietf.org/doc/html/rfc4180">standard
+        format.</a>
+
+        * The maximum batch size is 500.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          description: Can be text/csv or application/json
+          example: text/csv
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          description: Can be text/csv or application/json
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/:{object_name}/:{object_record_id}/actions/cascadedelete:
+    post:
+      tags:
+        - Vault Objects
+      summary: Cascade Delete Object Record
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Cascade_Delete_Object_Record
+
+
+        This asynchronous endpoint will delete a single parent object record and
+        all related children and grandchildren.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_record_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/cascadedelete/results/:{object_name}/:{job_status}/:{job_id}:
+    get:
+      tags:
+        - Vault Objects
+      summary: Retrieve Results of Cascade Delete Job
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Get_Results_Cascade_Delete
+
+
+        After submitting a request to cascade delete an object record, you can
+        query Vault to determine the results of the request.
+
+
+        Before submitting this request:
+
+
+        * You must have previously requested a cascade delete job (via the API)
+        which is no longer active.
+
+        * You must have a valid `job_id value`, retrieved from the response of
+        the cascade delete request.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: job_status
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: job_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/:{object_name}/:{object_record_id}/actions/deepcopy:
+    post:
+      tags:
+        - Vault Objects
+      summary: Deep Copy Object Record with Override
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Deep_Copy_Object_Record
+
+
+
+        Deep Copy copies an object record, including all of the record’s related
+        child
+
+        and grandchild records. Each deep (hierarchical) copy can copy a maximum
+        of
+
+        10,000 related records at a time.
+
+
+        See <a target="_blank"
+        href="https://platform.veevavault.help/en/lr/32218">Copying Object
+        Records</a> for details on required access permissions.
+
+
+        **Note:** You can perform a regular copy of an object record using the
+        <a
+        href="https://developer.veevavault.com/api/25.1/#Create_Object_Record">Create
+        Object</a> endpoint with the <code
+        class="prettyprint">source_record_id</code> field.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                - name__v: Copied record 1
+                  external_id__v: ''
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_record_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/deepcopy/results/:{object_name}/:{job_status}/:{job_id}:
+    get:
+      tags:
+        - Vault Objects
+      summary: Retrieve Results of Deep Copy Job
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Get_Results_Deep_Copy
+
+
+        After submitting a request to deep copy an object record, you can query
+        Vault to determine the results of the request.
+
+
+        Before submitting this request:
+
+
+        * You must have previously requested a deep copy job (via the API) which
+        is no longer active.
+
+        * You must have a valid `job_id` value, retrieved from the response of
+        the deep copy request.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: job_status
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: job_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/deletions/vobjects/:{object_name}:
+    get:
+      tags:
+        - Vault Objects
+      summary: Retrieve Deleted Object Record ID
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Retrieve_Deleted_Object_Records
+
+
+        Retrieve the IDs of object records that have been deleted from your
+        Vault within the past 30 days. After object records are deleted from a
+        Vault, their IDs are still available for retrieval for 30 days. After
+        that, they cannot be retrieved. You can use the optional request
+        parameters below to narrow the results to a specific date and time range
+        within the past 30 days.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/limits:
+    get:
+      tags:
+        - Vault Objects
+      summary: Retrieve Limits on Objects
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Retrieve_Limits_Objects
+
+
+        Vault limits the number of object records that can be created for each
+        object (`product__v`, `study__v`, `custom_object__c`, etc.). There is
+        also a limit to the number of custom objects that can be created in each
+        Vault. To retrieve these limits:
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/:{object_name}/actions/updatecorporatecurrency:
+    put:
+      tags:
+        - Vault Objects
+      summary: Update Corporate Currency Fields
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Update_Object_Corp_Currency
+
+
+        Currency is a field type available on all Vault objects. Whenever a user
+        populates a local currency field value, Vault automatically populates
+        the related corporate currency field value, except in the following
+        scenarios:
+
+
+        * Admins change the Corporate Currency setting for the vault
+
+        * Admins update the Rate setting for the local currency used by a record
+
+
+        This endpoint updates the `field_corp__sys` field values of an object
+        record based on the Rate of the currency, denoted by the
+        `local_currency__sys` field of the specified record. Learn more about <a
+        href="https://platform.veevavault.help/en/lr/50532">Currency Fields</a>
+        in Vault Help.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{id}/roles:
+    get:
+      tags:
+        - Document & Binder Roles > Document Roles
+      summary: Retrieve All Document Roles
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Roles
+
+
+
+        Retrieve all available roles on a document and the users and groups
+        assigned to them.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Document & Binder Roles > Document Roles
+      summary: Assign Users & Groups to Roles on a Single Document
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Assign_Users_Groups_to_Role
+
+
+
+        **Note:** If you need to assign users and groups to roles on more than
+        one document, it is best practice to use the <a
+        href="https://developer.veevavault.com/api/25.1/#Assign_Users_Groups_to_Roles">bulk
+        API</a>.
+
+
+        Assign users and groups to roles on a single document.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{id}/roles/:{role_name}:
+    get:
+      tags:
+        - Document & Binder Roles > Document Roles
+      summary: Retrieve Document Role
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Role
+
+
+
+        Retrieve a specific role on a document and the users and groups assigned
+        to it.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: role_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/roles/batch:
+    post:
+      tags:
+        - Document & Binder Roles > Document Roles
+      summary: Assign Users & Groups to Roles on Multiple Documents & Binders
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Assign_Users_Groups_to_Roles
+
+
+
+        Assign users and groups to roles on documents and binders in bulk.
+
+
+        * The maximum CSV input file size is 1GB.
+
+        * The values in the input must be UTF-8 encoded.
+
+        * CSVs must follow the <a href
+        ="https://datatracker.ietf.org/doc/html/rfc4180">standard format.</a>
+
+        * The maximum batch size is 1000.
+
+
+        Assigning users and groups to document roles is additive. For example,
+        if groups 1, 2, and 3 are currently assigned to a particular role and
+        you assign groups 3, 4, and 5 to the same role, the final list of groups
+        assigned to the role will be 1, 2, 3, 4, and 5. Users and groups (IDs)
+        in the input that are either invalid (not recognized) or cannot be
+        assigned to a role due to permissions are ignored and not processed.
+
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Document & Binder Roles > Document Roles
+      summary: Remove Users and Groups from Roles on Multiple Documents & Binders
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Remove_Users_Groups_from_Roles
+
+
+
+        Remove users and groups from roles on documents and binders in bulk.
+
+
+        * The maximum CSV input file size is 1GB.
+
+        * The values in the input must be UTF-8 encoded.
+
+        * CSVs must follow the <a href
+        ="https://datatracker.ietf.org/doc/html/rfc4180">standard format.</a>
+
+        * The maximum batch size is 1000.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/roles/:{role_name_and_user_or_group}/:{id}:
+    delete:
+      tags:
+        - Document & Binder Roles > Document Roles
+      summary: Remove Users & Groups from Roles on a Single Document
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Remove_Users_Groups_from_Role
+
+
+
+        **Note:** If you need to remove users and groups from roles on more than
+        one document, it is best practice to use the <a
+        href="https://developer.veevavault.com/api/25.1/#Remove_Users_Groups_from_Roles">bulk
+        API</a>.
+
+
+        Remove users and groups from roles on a single document.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: ''
+          in: header
+          schema:
+            type: string
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: role_name_and_user_or_group
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/:{id}/roles:
+    get:
+      tags:
+        - Document & Binder Roles > Binder Roles
+      summary: Retrieve All Binder Roles
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Binder_Roles
+
+
+
+        Retrieve all available roles on a binder and the users and groups
+        assigned to them.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Document & Binder Roles > Binder Roles
+      summary: Assign Users & Groups to Roles on a Single Binder
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Assign_Users_Groups_to_Role_Single_Binder
+
+
+
+        **Note:** To assign users and groups to roles on multiple binders, use
+        the <a
+        href="https://developer.veevavault.com/api/25.1/#Assign_Users_Groups_to_Roles">Assign
+        Users & Groups to Roles on Multiple Documents & Binders</a> endpoint.
+
+
+        Assign users and groups to roles on a single document.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/:{id}/roles/:{role_name}:
+    get:
+      tags:
+        - Document & Binder Roles > Binder Roles
+      summary: Retrieve Document Role
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Binder_Role
+
+
+
+        Retrieve a specific role on a binder and the users and groups assigned
+        to it.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: role_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/:{binder_id}/roles/:{role_name_and_user_or_group}/:{id}:
+    delete:
+      tags:
+        - Document & Binder Roles > Binder Roles
+      summary: Remove Users & Groups from Roles on a Single Binder
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Remove_Users_Groups_from_Role_Single_Binder
+
+
+
+        **Note:** To remove users and groups from roles on multiple binders, use
+        the <a
+        href="https://developer.veevavault.com/api/25.1/#Remove_Users_Groups_from_Roles">Assign
+        Users & Groups to Roles on Multiple Documents & Binders</a> endpoint.
+
+
+        Remove users and groups from roles on a single binder.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: ''
+          in: header
+          schema:
+            type: string
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: binder_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: role_name_and_user_or_group
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/objectworkflows/tasks:
+    get:
+      tags:
+        - Workflows > Workflow Tasks
+      summary: Retrieve Workflow Tasks
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Object_Workflow_Tasks
+
+
+
+        Retrieve all available tasks across all workflows.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: object__v
+          in: query
+          schema:
+            type: string
+          description: >-
+            To retrieve all workflow tasks configured on an object, include the
+            Vault object name__v and object record id field values as
+            ?object__v={name__v}&record_id__v={id}. These two parameters are
+            required when the assignee__v parameter is not used.
+        - name: record_id__v
+          in: query
+          schema:
+            type: string
+          description: >-
+            To retrieve all workflow tasks configured on an object, include the
+            Vault object name__v and object record id field values as
+            ?object__v={name__v}&record_id__v={id}. These two parameters are
+            required when the assignee__v parameter is not used.
+        - name: assignee__v
+          in: query
+          schema:
+            type: string
+          description: >
+            To retrieve all workflow tasks available to a particular user,
+            include the user id field value as ?assignee__v={id}. To retrieve
+            your own workflow tasks, set this value to ?assignee__v=me. This
+            parameter is required when the object__v and record_id__v parameters
+            are not used.
+        - name: status__v
+          in: query
+          schema:
+            type: string
+          description: >
+            To retrieve all workflow tasks with specific statuses, include one
+            or more status name__v field values. For example:
+            ?status__v=available__v or ?status__v=available__v,completed__v.
+        - name: offset
+          in: query
+          schema:
+            type: string
+          description: >
+            This parameter is used to paginate the results. It specifies the
+            amount of offset from the first record returned. Vault returns 200
+            records per page by default. If you are viewing the first 200
+            results (page 1) and want to see the next page, set this to
+            ?offset=201.
+        - name: page_size
+          in: query
+          schema:
+            type: string
+          description: >
+            This parameter is used to paginate the results. It specifies the
+            size number of records to display per page. Vault returns 200
+            records per page by default. You can set this value lower or as high
+            as 1000 records per page. For example: ?page_size=1000.
+        - name: loc
+          in: query
+          schema:
+            type: string
+          description: >
+            When localized (translated) strings are available, retrieve them by
+            including ?loc=true.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/objectworkflows/tasks/:{task_id}:
+    get:
+      tags:
+        - Workflows > Workflow Tasks
+      summary: Retrieve Workflow Task Details
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Workflow_Task_Details
+
+
+
+        Retrieve the details of a specific workflow task.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: loc
+          in: query
+          schema:
+            type: boolean
+          description: >-
+            When localized (translated) strings are available, retrieve them by
+            including loc=true.
+          example: 'true'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: task_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/objectworkflows/tasks/:{task_id}/actions:
+    get:
+      tags:
+        - Workflows > Workflow Tasks
+      summary: Retrieve Workflow Task Actions
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Workflow_Task_Actions
+
+
+
+        Retrieve all available actions that can be initiated on a given workflow
+        task.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: task_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/objectworkflows/tasks/:{task_id}/actions/:{task_action}:
+    get:
+      tags:
+        - Workflows > Workflow Tasks
+      summary: Retrieve Workflow Task Action Details
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Workflow_Task_Action_Details
+
+
+
+        Retrieve the details of a specific workflow task action. The response
+        lists the details of the task action, including all fields required to
+        initiate the action. Note that task actions where `esignature` is `true`
+        cannot be initiated via the API.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: loc
+          in: query
+          schema:
+            type: string
+          description: >
+            When localized (translated) strings are available, retrieve them by
+            including loc=true.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: task_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: task_action
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/objectworkflows/tasks/:{task_id}/actions/mdwaccept:
+    post:
+      tags:
+        - Workflows > Workflow Tasks
+      summary: Accept Multi-item Workflow Task
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Accept_Multi-item_Workflow_Task](https://developer.veevavault.com/api/25.1/#Accept_Multi-item_Workflow_Task)
+
+
+        Accept an available task for a multi-item workflow. If the task is
+        available to multiple users, any one of the assigned users can accept
+        the task. To undo your acceptance of an available workflow task, use
+        [Undo Workflow Task
+        Acceptance](https://developer.veevavault.com/api/25.1/#Undo_Workflow_Task_Acceptance).
+
+
+        Vault may prevent you from accepting a task if you've already accepted,
+        assigned, or completed another task, or have a restricted role.
+
+
+        #### Example Response
+
+
+        ``` json
+
+        {
+            "responseStatus": "SUCCESS"
+        }
+
+         ```
+
+        #### Response Details
+
+
+        On `SUCCESS`, Vault accepts the available workflow task on behalf of the
+        authenticated user.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: task_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/objectworkflows/tasks/:{task_id}/actions/accept:
+    post:
+      tags:
+        - Workflows > Workflow Tasks
+      summary: Accept Single Record Workflow Task
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Accept_Single_Record_Workflow_Task](https://developer.veevavault.com/api/25.1/#Accept_Single_Record_Workflow_Task)
+
+
+        Accept an available task for a workflow configured for a single record.
+        If the task is available to multiple users, any one of the assigned
+        users can accept the task. To undo your acceptance of an available
+        workflow task, use [Undo Workflow Task
+        Acceptance](https://developer.veevavault.com/api/25.1/#Undo_Workflow_Task_Acceptance).
+
+
+        Vault may prevent you from accepting a task if you've already accepted,
+        assigned, or completed another task, or have a restricted role.
+
+
+        #### Example Response
+
+
+        ``` json
+
+        {
+            "responseStatus": "SUCCESS"
+        }
+
+         ```
+
+        #### Response Details
+
+
+        On `SUCCESS`, Vault accepts the available workflow task on behalf of the
+        authenticated user.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: task_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/objectworkflows/tasks/:{task_id}/actions/undoaccept:
+    post:
+      tags:
+        - Workflows > Workflow Tasks
+      summary: Undo Workflow Task Acceptance
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Undo_Workflow_Task_Acceptance](https://developer.veevavault.com/api/25.1/#Undo_Workflow_Task_Acceptance)
+
+
+        Undo your acceptance of an available workflow task. Once released, the
+        task is available again to any of the assigned users. This endpoint
+        supports single and multi-item workflows.
+
+
+        #### Example Response
+
+
+        ``` json
+
+        {
+            "responseStatus": "SUCCESS"
+        }
+
+         ```
+
+        #### Response Details
+
+
+        On `SUCCESS`, Vault releases the available workflow task on behalf of
+        the authenticated user. The task is available again to any of the
+        assigned users.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: task_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/objectworkflows/tasks/:{task_id}/actions/mdwcomplete:
+    post:
+      tags:
+        - Workflows > Workflow Tasks
+      summary: Complete Multi-item Workflow Task
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Complete_Multi-item_Workflow_Task](https://developer.veevavault.com/api/25.1/#Complete_Multi-item_Workflow_Task)
+
+
+        Complete an open workflow task for a multi-item workflow. This endpoint
+        does not support initiating task actions requiring eSignatures (where
+        esignature is true). To provide multiple verdicts for items without
+        completing an open workflow task, use [Manage Multi-item Workflow
+        Content](https://developer.veevavault.com/api/25.1/#Manage_Multi-item_Workflow_Content).
+
+
+        #### Body Parameters
+
+
+        Controls with `required=true` in the [Retrieve Workflow Task Action
+        Details](https://developer.veevavault.com/api/23.3/#Retrieve_Workflow_Task_Action_Details)
+        response must be provided. If a control (such as `verdict`) defines a
+        set of required fields, those must also be provided. For example, a
+        specific verdict may prompt for comments, reasons, or capacities.
+
+
+        For workflows where `type` is set to `multidocworkflow` and
+        `cardinality` is set to `One`, Vault pre-populates document field values
+        in field prompts. If you include keys for field prompts without values,
+        Vault submits a blank field value on the document.
+
+
+        In the body of the request, upload parameters as a JSON file. This
+        request may require the following body parameters:
+
+
+        | **Name** | **Description** |
+
+        | --- | --- |
+
+        | `verdict_public_key__c`  <br>**conditional** | The verdict name.
+        Retrieve possible verdict `name` values by sending a request to
+        [Retrieve Workflow Task Action
+        Details](https://developer.veevavault.com/api/23.3/#Retrieve_Workflow_Task_Action_Details).
+        |
+
+        | `reason__c`  <br>**conditional** | The reason name. Retrieve possible
+        reason `name` values by sending a request to [Retrieve Workflow Task
+        Action
+        Details](https://developer.veevavault.com/api/23.3/#Retrieve_Workflow_Task_Action_Details).
+        |
+
+        | `capacity__c`  <br>**conditional** | The capacity name. Retrieve
+        possible capacity `name` values by sending a request to [Retrieve
+        Workflow Task Action
+        Details](https://developer.veevavault.com/api/23.3/#Retrieve_Workflow_Task_Action_Details).
+        |
+
+
+        #### **Example JSON Request Body: Single Verdict**
+
+
+        ``` json
+
+        {
+           "verdict_public_key__c": "verdict_not_approved__c",
+           "verdict_not_approved_comment__c": "Needs to be redone."
+        }
+
+         ```
+
+        #### **Example JSON Request Body: Multiple Verdicts**
+
+
+        ``` json
+
+        {
+           "task_comment__v": "Some of these batches need to be reprocessed.",
+           "contents__sys": [
+        {
+                 "object__v": "batch__v",
+                 "record_id__v": "0BA000000000101",
+               "verdict_public_key__c": "verdict_not_approved__c",
+               "verdict_not_approved_comment__c": "Needs to be redone."
+             },
+             {
+                 "object__v": "batch__v",
+                 "record_id__v": "0BA000000002001",
+               "verdict_public_key__c": "verdict_approved__c"
+             },
+            {
+                 "object__v": "batch__v",
+                 "record_id__v": "0BA000000002002",
+               "verdict_public_key__c": "verdict_not_approved__c",
+               "verdict_not_approved_comment__c": "Does not meet standards."
+             }
+           ]
+        }
+
+         ```
+
+        #### Example Response
+
+
+        ``` json
+
+        {
+            "responseStatus": "SUCCESS"
+        }
+
+         ```
+
+        #### Response Details
+
+
+        On `SUCCESS`, Vault completes the workflow task on behalf of the
+        authenticated user.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example: ''
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: task_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/objectworkflows/tasks/:{task_id}/actions/complete:
+    post:
+      tags:
+        - Workflows > Workflow Tasks
+      summary: Complete Single Record Workflow Task
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Complete_Single_Record_Workflow_Task](https://developer.veevavault.com/api/25.1/#Complete_Single_Record_Workflow_Task)
+
+
+        Complete an open workflow task for a workflow configured for a single
+        record. This endpoint does not support initiating task actions requiring
+        eSignatures (where `esignature` is `true`).
+
+
+        #### Body Parameters
+
+
+        Controls with `required=true` in the [Retrieve Workflow Task Action
+        Details](https://developer.veevavault.com/api/23.3/#Retrieve_Workflow_Task_Action_Details)
+        response must be provided. If a control (such as `verdict`) defines a
+        set of required fields, those must also be provided. For example, a
+        specific verdict may prompt for comments, reasons, or capacities.
+
+
+        This request may require the following body parameters:
+
+
+        | **Name** | **Description** |
+
+        | --- | --- |
+
+        | `verdict_public_key__c`  <br>**conditional** | The verdict name.
+        Retrieve possible verdict `name` values by sending a request to
+        [Retrieve Workflow Task Action
+        Details](https://developer.veevavault.com/api/23.3/#Retrieve_Workflow_Task_Action_Details).
+        |
+
+        | `reason__c`  <br>**conditional** | The reason name. Retrieve possible
+        reason `name` values by sending a request to [Retrieve Workflow Task
+        Action
+        Details](https://developer.veevavault.com/api/23.3/#Retrieve_Workflow_Task_Action_Details).
+        |
+
+        | `capacity__c`  <br>**conditional** | The capacity name. Retrieve
+        possible capacity `name` values by sending a request to [Retrieve
+        Workflow Task Action
+        Details](https://developer.veevavault.com/api/23.3/#Retrieve_Workflow_Task_Action_Details).
+        |
+
+
+        #### Example Response
+
+
+        ``` json
+
+        {
+            "responseStatus": "SUCCESS"
+        }
+
+         ```
+
+        #### Response Details
+
+
+        On `SUCCESS`, Vault completes the workflow task on behalf of the
+        authenticated user.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: task_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/objectworkflows/tasks/:{task_id}/actions/mdwreassign:
+    post:
+      tags:
+        - Workflows > Workflow Tasks
+      summary: Reassign Multi-item Workflow Task
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Reassign_Multi-item_Workflow_Task](https://developer.veevavault.com/api/25.1/#Reassign_Multi-item_Workflow_Task)
+
+
+        Reassign an open workflow task to another user for a multi-item
+        workflow.
+
+
+        You cannot reassign a task to a user who is already assigned to that
+        specific task, has completed that task, or is configured with a
+        restricted role. However, you can reassign a user to continuing
+        iterations of the same task if an Admin has enabled users in the
+        workflow to only complete one task.
+
+
+        #### Example Response
+
+
+        ``` json
+
+        {
+            "responseStatus": "SUCCESS"
+        }
+
+         ```
+
+        #### Response Details
+
+
+        Returns `SUCCESS` if the task was successfully reassigned. Vault
+        notifies the new task owner and the previous task owner of the
+        reassignment.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: task_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/objectworkflows/tasks/:{task_id}/actions/reassign:
+    post:
+      tags:
+        - Workflows > Workflow Tasks
+      summary: Reassign Single Record Workflow Task
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Reassign_Single_Record_Workflow_Task](https://developer.veevavault.com/api/25.1/#Reassign_Single_Record_Workflow_Task)
+
+
+        Reassign an open workflow task to another user for a workflow configured
+        for a single record.
+
+
+        You cannot reassign a task to a user who is already assigned to that
+        specific task, has completed that task, or is configured with a
+        restricted role. However, you can reassign a user to continuing
+        iterations of the same task if an Admin has enabled users in the
+        workflow to only complete one task.
+
+
+        #### Example Response
+
+
+        ``` json
+
+        {
+            "responseStatus": "SUCCESS"
+        }
+
+         ```
+
+        #### Response Details
+
+
+        Returns `SUCCESS` if the task was successfully reassigned. Vault
+        notifies the new task owner and the previous task owner of the
+        reassignment.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: task_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/objectworkflows/tasks/:{task_id}/actions/updateduedate:
+    post:
+      tags:
+        - Workflows > Workflow Tasks
+      summary: Update Workflow Task Due Date
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Update_Workflow_Task_Due_Date](https://developer.veevavault.com/api/25.1/#Update_Workflow_Task_Due_Date)
+
+
+        Update the due date of an assigned workflow task. This endpoint supports
+        single and multi-item workflows.
+
+
+        If the workflow is configured to set all task due dates to the workflow
+        due date, updates to individual task due dates will not affect the
+        overall workflow due date. You cannot update task due dates that are
+        configured to sync with an object or document field.
+
+
+        #### Example Response
+
+
+        ``` json
+
+        {
+            "responseStatus": "SUCCESS"
+        }
+
+         ```
+
+        #### Response Details
+
+
+        Returns `SUCCESS` if the due date was successfully updated. Vault
+        notifies the task owner of the new due date.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: task_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/objectworkflows/tasks/:{task_id}/actions/cancel:
+    post:
+      tags:
+        - Workflows > Workflow Tasks
+      summary: Cancel Workflow Task
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Cancel_Workflow_Task](https://developer.veevavault.com/api/25.1/#Cancel_Workflow_Task)
+
+
+        Cancel an open workflow task. This endpoint supports single and
+        multi-record workflows.
+
+
+        #### Example Response
+
+
+        ``` json
+
+        {
+            "responseStatus": "SUCCESS"
+        }
+
+         ```
+
+        #### Response Details
+
+
+        Returns `SUCCESS` if the task was canceled successfully.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: task_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/objectworkflows/tasks/:{task_id}/actions/mdwmanagecontent:
+    post:
+      tags:
+        - Workflows > Workflow Tasks
+      summary: Manage Multi-Item Workflow Content
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Manage_Multi-item_Workflow_Content](https://developer.veevavault.com/api/25.1/#Manage_Multi-item_Workflow_Content)
+
+
+        Manage content in a multi-item workflow without completing an open
+        workflow task. For example, you can use this endpoint to provide
+        verdicts for specific items without completing the task. This endpoint
+        does not support initiating task actions requiring eSignatures (where
+        `esignature` is `true`).
+
+
+        #### **Body Parameters**
+
+
+        Controls with `required=true` in the [Retrieve Workflow Task Action
+        Details](https://developer.veevavault.com/api/23.3/#Retrieve_Workflow_Task_Action_Details)
+        response can be provided. If a control (such as `verdict`) defines a set
+        of required fields, those can also be provided. For example, a specific
+        verdict may prompt for comments, reasons, or capacities.
+
+
+        In the body of the request, upload parameters as a JSON file. This
+        request may require the following body parameters:
+
+
+        | **Name** | **Description** |
+
+        | --- | --- |
+
+        | `verdict_public_key__c`  <br>**conditional** | The verdict name.
+        Retrieve possible verdict `name` values by sending a request to
+        [Retrieve Workflow Task Action
+        Details](https://developer.veevavault.com/api/23.3/#Retrieve_Workflow_Task_Action_Details).
+        |
+
+        | `reason__c`  <br>**conditional** | The reason name. Retrieve possible
+        reason `name` values by sending a request to [Retrieve Workflow Task
+        Action
+        Details](https://developer.veevavault.com/api/23.3/#Retrieve_Workflow_Task_Action_Details).
+        |
+
+        | `capacity__c`  <br>**conditional** | The capacity name. Retrieve
+        possible capacity `name` values by sending a request to [Retrieve
+        Workflow Task Action
+        Details](https://developer.veevavault.com/api/23.3/#Retrieve_Workflow_Task_Action_Details).
+        |
+
+
+        #### **Example JSON Request Body: Multiple Verdicts**
+
+
+        ``` json
+
+        {
+           "contents__sys": [
+        {
+                 "object__v": "batch__v",
+                 "record_id__v": "0BA000000000101",
+               "verdict_public_key__c": "verdict_not_approved__c",
+               "verdict_not_approved_comment__c": "Needs to be redone."
+             },
+             {
+                 "object__v": "batch__v",
+                 "record_id__v": "0BA000000002001",
+               "verdict_public_key__c": "verdict_approved__c"
+             },
+            {
+                 "object__v": "batch__v",
+                 "record_id__v": "0BA000000002002",
+               "verdict_public_key__c": "verdict_not_approved__c",
+               "verdict_not_approved_comment__c": "Does not meet standards."
+             }
+           ]
+        }
+
+         ```
+
+        #### **Example Response**
+
+
+        ``` json
+
+        {
+            "responseStatus": "SUCCESS"
+        }
+
+         ```
+
+        #### Response Details
+
+
+        On `SUCCESS`, Vault modifies the contents in the multi-item workflow
+        according to the JSON payload provided. Use [Retrieve Workflow Task
+        Action
+        Details](https://developer.veevavault.com/api/23.3/#Retrieve_Workflow_Task_Action_Details)
+        to confirm any changes to `current_values`. You must use [Complete
+        Multi-item Workflow
+        Task](https://developer.veevavault.com/api/25.1/#Complete_Multi-item_Workflow_Task)
+        to complete the open workflow task.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example: ''
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: task_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/object/workflow/actions:
+    get:
+      tags:
+        - Workflows > Bulk Active Workflow Actions
+      summary: Retrieve Bulk Workflow Actions
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Bulk_Workflow_Actions
+
+
+
+        Retrieve all available workflow actions that can be initiated on a
+        workflow which:
+
+
+        * The authenticated user has permissions to view or initiate
+
+        * Can be initiated through the API
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/object/workflow/actions/:action:
+    get:
+      tags:
+        - Workflows > Bulk Active Workflow Actions
+      summary: Retrieve Bulk Workflow Action Details
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Bulk_Workflow_Action_Details
+
+
+
+        Once you’ve retrieved the available workflow actions, use this request
+        to retrieve the details for a specific workflow action.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Workflows > Bulk Active Workflow Actions
+      summary: Initiate Workflow Actions on Multiple Workflows
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Initiate_Bulk_Workflow_Action
+
+
+
+        Use this request to initiate a workflow action on multiple workflows.
+        This starts an asynchronous job whose status you can check with the
+        Retrieve Job Status endpoint. Maximum 500 workflows per request.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/object/workflow/actions/cancelworkflows:
+    post:
+      tags:
+        - Workflows > Bulk Active Workflow Actions
+      summary: Cancel Workflows
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Initiate_Bulk_Workflow_Action
+
+
+        Use this request to initiate a workflow action on multiple workflows.
+        This starts an asynchronous job whose status you can check with the
+        Retrieve Job Status endpoint. Maximum 500 workflows per request.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/object/workflow/actions/canceltasks:
+    post:
+      tags:
+        - Workflows > Bulk Active Workflow Actions
+      summary: Cancel Workflow Tasks
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Initiate_Bulk_Workflow_Action
+
+
+        Use this request to initiate a workflow action on multiple workflows.
+        This starts an asynchronous job whose status you can check with the
+        Retrieve Job Status endpoint. Maximum 500 workflows per request.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/object/workflow/actions/reassigntasks:
+    post:
+      tags:
+        - Workflows > Bulk Active Workflow Actions
+      summary: Reassign Workflow Tasks
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Initiate_Bulk_Workflow_Action
+
+
+        Use this request to initiate a workflow action on multiple workflows.
+        This starts an asynchronous job whose status you can check with the
+        Retrieve Job Status endpoint. Maximum 500 workflows per request.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/object/workflow/actions/replaceworkflowowner:
+    post:
+      tags:
+        - Workflows > Bulk Active Workflow Actions
+      summary: Replace Workflow Owner
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Initiate_Bulk_Workflow_Action
+
+
+        Use this request to initiate a workflow action on multiple workflows.
+        This starts an asynchronous job whose status you can check with the
+        Retrieve Job Status endpoint. Maximum 500 workflows per request.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/objectworkflows:
+    get:
+      tags:
+        - Workflows
+      summary: Retrieve Workflows
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Retrieve_Workflows](https://developer.veevavault.com/api/25.1/#Retrieve_Workflows)
+
+
+        Retrieve all current, cancelled, and completed workflow instances for a
+        specific object record or all workflows available to a particular
+        workflow participant.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: object__v
+          in: query
+          schema:
+            type: string
+          description: >
+            To retrieve all workflows configured on an object, include the Vault
+            object name__v and object record id field values as
+            ?object__v={name__v}&record_id__v={id}. These two parameters are
+            required when the participant parameter is not used.
+        - name: record_id__v
+          in: query
+          schema:
+            type: string
+          description: >
+            To retrieve all workflows configured on an object, include the Vault
+            object name__v and object record id field values as
+            ?object__v={name__v}&record_id__v={id}. These two parameters are
+            required when the participant parameter is not used.
+        - name: participant
+          in: query
+          schema:
+            type: string
+          description: >
+            To retrieve all workflows available to a particular user, include
+            the user id field value as ?participant={id}. To retrieve your own
+            workflows, set this value to ?participant=me. This parameter is
+            required when the object__v and record_id__v parameters are not
+            used.
+        - name: status__v
+          in: query
+          schema:
+            type: string
+          description: >-
+            To retrieve all workflows with specific statuses, include one or
+            more status name__v field values. For example: status__v=active__v,
+            status__v=active__v,completed__v. Workflows with
+            `status__v=active__v` are in progress for the indicated object
+            record. Valid statuses include:
+
+            active__v
+
+            completed__v
+
+            cancelled__v
+        - name: offset
+          in: query
+          schema:
+            type: string
+          description: >
+            This parameter is used to paginate the results. It specifies the
+            amount of offset from the first record returned. Vault returns 200
+            records per page by default. If you are viewing the first 200
+            results (page 1) and want to see the next page, set this to
+            ?offset=201.
+        - name: page_size
+          in: query
+          schema:
+            type: string
+          description: >
+            This parameter is used to paginate the results. It specifies the
+            size number of records to display per page. Vault returns 200
+            records per page by default. You can set this value lower or as high
+            as 1000 records per page. For example: ?page_size=1000.
+        - name: loc
+          in: query
+          schema:
+            type: string
+          description: >
+            When localized (translated) strings are available, retrieve them by
+            including ?loc=true.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/objectworkflows/:{workflow_id}:
+    get:
+      tags:
+        - Workflows
+      summary: Retrieve Workflow Details
+      description: |-
+        https://developer.veevavault.com/api/25.1/#Retrieve_Workflow_Details
+
+        Retrieve the details for a specific object workflow.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: loc
+          in: query
+          schema:
+            type: boolean
+          description: >-
+            When localized (translated) strings are available, retrieve them by
+            including loc=true.
+          example: 'true'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: workflow_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/objectworkflows/:{workflow_id}/actions:
+    get:
+      tags:
+        - Workflows
+      summary: Retrieve Workflow Actions
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Retrieve_Workflow_Actions
+
+
+        Retrieve all available workflow actions that can be initiated on a
+        specific object workflow.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: loc
+          in: query
+          schema:
+            type: string
+          description: >
+            When localized (translated) strings are available, retrieve them by
+            including loc=true.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: workflow_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/objectworkflows/:{workflow_id}/actions/:{workflow_action}:
+    get:
+      tags:
+        - Workflows
+      summary: Retrieve Workflow Action Details
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Retrieve_Workflow_Action_Details
+
+
+        Retrieve details about a workflow action. For example, the `prompts`
+        needed to complete a workflow action.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: workflow_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: workflow_action
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Workflows
+      summary: Initiate Workflow Action
+      description: |-
+        https://developer.veevavault.com/api/25.1/#Initiate_Workflow_Action
+
+        Initiate a workflow action on a specific object workflow.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: documents__sys
+          in: query
+          schema:
+            type: string
+          description: >-
+            Include the id or ids as a comma-separated list of the document(s)
+            to be removed from a document workflow when using the removecontent
+            action.
+
+            If your workflow_action is remove_content, include the id of the
+            document to remove the workflow. To remove multiple documents, use a
+            comma-separated list of ids.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: workflow_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: workflow_action
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{id}/versions/:{major_version}/:{minor_version}/lifecycle_actions:
+    get:
+      tags:
+        - Document Lifecycle & Workflows > Document User Actions
+      summary: Retrieve Document User Actions
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Lifecycle_Actions
+
+
+
+        Retrieve all available user actions on a specific version of a document
+        which:
+
+
+        * The authenticated user has permissions to view or initiate.
+
+        * Can be initiated through the API. See <a
+        href="https://developer.veevavault.com/api/24.3#Document_Binder_Lifecycle_Actions">supported
+        user actions</a>.
+
+        * Is not currently in an active workflow.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/lifecycle_actions:
+    post:
+      tags:
+        - Document Lifecycle & Workflows > Document User Actions
+      summary: Retrieve User Actions on Multiple Documents
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Multiple_Document_User_Actions
+
+
+
+        Retrieve all available user actions on specific versions of multiple
+        documents.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{id}/versions/:{major_version}/:{minor_version}/lifecycle_actions/:{name__v}/entry_requirements:
+    get:
+      tags:
+        - Document Lifecycle & Workflows > Document User Actions
+      summary: Retrieve Document Entry Criteria
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Entry_Requirements
+
+
+
+        Retrieve the entry criteria for a user action. Entry criteria are
+        requirements the document must meet before you can <a
+        href="https://developer.veevavault.com/api/24.3#Initiate_Lifecycle_Action">initiate
+        the action</a>. Entry criteria are dynamic and depend on the lifecycle
+        configuration, lifecycle state, or any workflow activation requirements
+        defined in the *Start Step* of the workflow. Learn more about <a
+        href="https://platform.veevavault.help/en/lr/12617#types">entry criteria
+        in Vault Help</a>.
+
+
+        To retrieve entry criteria, the authenticated user must have permission
+        to execute the action. To check permissions, <a
+        href="https://developer.veevavault.com/api/24.3#Retrieve_Lifecycle_Actions">Retrieve
+        User Actions</a> and check for actions where `executable__v` is `true`.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: name__v
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{id}/versions/:{major_version}/:{minor_version}/lifecycle_actions/:{name__v}:
+    put:
+      tags:
+        - Document Lifecycle & Workflows > Document User Actions
+      summary: Initiate Document User Action
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Initiate_Lifecycle_Action
+
+
+
+        Initiate a user action. Before initiating, you should retrieve any
+        applicable <a
+        href="https://developer.veevavault.com/api/24.3#Retrieve_Entry_Requirements">entry
+        criteria</a> for the action.
+
+
+        Only some user action types can be initiated through the API. See <a
+        href="https://developer.veevavault.com/api/24.3#Document_Binder_Lifecycle_Actions">supported
+        user actions</a>.
+
+
+        The authenticated user must have permission to initiate this action. To
+        check permissions, <a
+        href="https://developer.veevavault.com/api/24.3#Retrieve_Lifecycle_Actions">Retrieve
+        User Actions</a> and check for actions where `executable__v` is `true`.
+
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example: ''
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: name__v
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/actions/:{lifecycle_and_state_and_action}/:{job_id}/results:
+    get:
+      tags:
+        - Document Lifecycle & Workflows > Document User Actions
+      summary: Download Controlled Copy Job Results
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Download_Controlled_Copy
+
+
+
+        **Note:** This endpoint is intended for use by integrations requesting
+        and routing controlled copies of content as a system integrations
+        account on behalf of users.
+
+
+        This endpoint is for Extensible Controlled Copy;
+        `controlled_copy_trace__v` and `controlled_copy_user_input__v` objects.
+        If your organization is not using these objects, you should use the
+        endpoints for <a
+        href="https://developer.veevavault.com/api/24.3#Document_Events">Legacy
+        Controlled Copy</a>.
+
+
+        After initiating a controlled copy user action, use this endpoint to
+        download the controlled copy. To execute this request in an integration
+        flow, <a
+        href="https://developer.veevavault.com/api/24.3#RetrieveJobStatus">Retrieve
+        the Job Status</a> and use the `href` under `"rel": "artifacts"`. We do
+        not recommend executing this request outside of this flow.
+
+
+        Before submitting this request:
+
+
+        * You must have previously requested an initiate controlled copy job
+        (via the API) which is no longer active
+
+        * You must be the user who initiated the job or have the *Admin: Jobs:
+        Read* permission
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: lifecycle_and_state_and_action
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: job_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/lifecycle_actions/:{user_action_name}:
+    put:
+      tags:
+        - Document Lifecycle & Workflows > Document User Actions
+      summary: Initiate Bulk Document User Actions
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Bulk_Document_State_Change
+
+
+
+        For each bulk action, you may only select a single workflow that Vault
+        will start for all selected and valid documents.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: user_action_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/:{id}/versions/:{major_version}/:{minor_version}/lifecycle_actions:
+    get:
+      tags:
+        - Document Lifecycle & Workflows > Binder User Actions
+      summary: Retrieve Binder User Actions
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Binder_User_Actions
+
+
+
+        Retrieve all available user actions on a specific version of a binder
+        which:
+
+
+        * The authenticated user has permissions to view or initiate.
+
+        * Can be initiated through the API. See <a
+        href="https://developer.veevavault.com/api/24.3#Document_Binder_Lifecycle_Actions">supported
+        user actions</a>.
+
+        * Is not currently in an active workflow.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/lifecycle_actions:
+    post:
+      tags:
+        - Document Lifecycle & Workflows > Binder User Actions
+      summary: Retrieve User Actions on Multiple Binders
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Multiple_Binder_User_Actions
+
+
+
+        Retrieve all available user actions on specific versions of multiple
+        binders.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/:{id}/versions/:{major_version}/:{minor_version}/lifecycle_actions/:{name__v}/entry_requirements:
+    get:
+      tags:
+        - Document Lifecycle & Workflows > Binder User Actions
+      summary: Retrieve Binder Entry Criteria
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Entry_Requirements_Binders
+
+
+
+        Retrieve the entry criteria for a user action. Entry criteria are
+        requirements the document must meet before you can <a
+        href="https://developer.veevavault.com/api/24.3#Initiate_Lifecycle_Action">initiate
+        the action</a>. Entry criteria are dynamic and depend on the lifecycle
+        configuration, lifecycle state, or any workflow activation requirements
+        defined in the *Start Step* of the workflow. Learn more about <a
+        href="https://platform.veevavault.help/en/lr/12617#types">entry criteria
+        in Vault Help</a>.
+
+
+        To retrieve entry criteria, the authenticated user must have permission
+        to execute the action. To check permissions, <a
+        href="https://developer.veevavault.com/api/24.3#Retrieve_Lifecycle_Actions">Retrieve
+        User Actions</a> and check for actions where `executable__v` is `true`.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: name__v
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/:{id}/versions/:{major_version}/:{minor_version}/lifecycle_actions/:{name__v}:
+    put:
+      tags:
+        - Document Lifecycle & Workflows > Binder User Actions
+      summary: Initiate Binder User Action
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Initiate_Binder_User_Action
+
+
+
+        Initiate a user action. Before initiating, you should retrieve any
+        applicable <a
+        href="https://developer.veevavault.com/api/24.3#Retrieve_Entry_Requirements">entry
+        criteria</a> for the action.
+
+
+        Only some user action types can be initiated through the API. See <a
+        href="https://developer.veevavault.com/api/24.3#Document_Binder_Lifecycle_Actions">supported
+        user actions</a>.
+
+
+        The authenticated user must have permission to initiate this action. To
+        check permissions, <a
+        href="https://developer.veevavault.com/api/24.3#Retrieve_Lifecycle_Actions">Retrieve
+        User Actions</a> and check for actions where `executable__v` is `true`.
+
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example: ''
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: major_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: minor_version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: name__v
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/binders/lifecycle_actions/:{user_action_name}:
+    put:
+      tags:
+        - Document Lifecycle & Workflows > Binder User Actions
+      summary: Initiate Bulk Binder User Actions
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Initiate_Bulk_Binder_User_Actions
+
+
+
+        For each bulk action, you may only select a single workflow that Vault
+        will start for all selected and valid binders.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: user_action_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/configuration/role_assignment_rule:
+    get:
+      tags:
+        - Document Lifecycle & Workflows > Lifecycle Role Assignment Rules
+      summary: Retrieve Lifecycle Role Assignment Rules (Default & Override)
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Lifecycle_Role_Assignment_Rules
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: lifecycle__v
+          in: query
+          schema:
+            type: string
+          description: >-
+            Include the name of the lifecycle from which to retrieve
+            information. For example: lifecycle_v=general_lifecycle__c
+        - name: role__v
+          in: query
+          schema:
+            type: string
+          description: >-
+            Include the name of the role from which to retrieve information. For
+            example: role__v=editor__c
+        - name: product__v
+          in: query
+          schema:
+            type: string
+          description: >-
+            Include the ID/name of a specific product to see product-based
+            override rules to default users/allowed users for the lifecycle
+            role. For example: product__v=0PR0011001 or
+            product__v.name__v=CholeCap
+        - name: country__v
+          in: query
+          schema:
+            type: string
+          description: >-
+            Include the ID/name of a specific country to see country-based
+            override rules to default users/allowed users for the lifecycle
+            role. For example: country__v=0CR0022002 or
+            country__v.name__v=United States
+        - name: study__v
+          in: query
+          schema:
+            type: string
+          description: >-
+            In eTMF Vaults only. Include the ID/name of a specific study to see
+            study-based override rules to default users/allowed users for the
+            lifecycle role. For example: study__v=0ST0021J01 or
+            study__v.name__v=CholeCap Study
+        - name: study_country__v
+          in: query
+          schema:
+            type: string
+          description: >-
+            In eTMF Vaults only. Include the ID/name of a specific study country
+            to see study country-based override rules to default users/allowed
+            users for the lifecycle role. For example:
+            study_country__v=0SC0001001 or study_country__v.name__v=Germany
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Document Lifecycle & Workflows > Lifecycle Role Assignment Rules
+      summary: Create Lifecycle Role Assignment Override Rules
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Create_Override_Rules
+
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - Document Lifecycle & Workflows > Lifecycle Role Assignment Rules
+      summary: Update Lifecycle Role Assignment Rules (Default & Override)
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Update_Override_Rules
+
+
+
+        Before submitting this request, prepare a JSON or CSV input file. See
+        the <a
+        href="https://developer.veevavault.com/api/24.3#Create_Override_Rules">Create
+        Lifecycle Role Assignment Override Rules</a> request above for details.
+
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Document Lifecycle & Workflows > Lifecycle Role Assignment Rules
+      summary: Delete Lifecycle Role Assignment Override Rules
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Delete_Override_Rules
+
+
+        Delete override rules configured on a specific lifecycle role.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/actions:
+    get:
+      tags:
+        - Document Lifecycle & Workflows > Document Workflows
+      summary: Retrieve All Document Workflows
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_All_Multi_Document_Workflows
+
+
+
+        Retrieve all available document workflows that can be initiated on a set
+        of documents which:
+
+
+        * The authenticated user has permissions to view or initiate
+
+        * Can be initiated through the API
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: loc
+          in: query
+          schema:
+            type: boolean
+          description: >-
+            When localized (translated) strings are available, retrieve them by
+            setting loc to true.
+          example: 'true'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/actions/:{workflow_name}:
+    get:
+      tags:
+        - Document Lifecycle & Workflows > Document Workflows
+      summary: Retrieve Document Workflow Details
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Multi_Document_Workflow_Details
+
+
+
+        Retrieves the details for a specific document workflow.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: loc
+          in: query
+          schema:
+            type: boolean
+          description: >-
+            When localized (translated) strings are available, retrieve them by
+            setting loc to true.
+          example: 'true'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: workflow_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Document Lifecycle & Workflows > Document Workflows
+      summary: Initiate Document Workflow
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Initiate_Multi_Document_Workflow
+
+
+
+        Initiate a document workflow on a set of documents. If any document is
+        not in the relevant state or does not meet configured field conditions,
+        the API returns  `INVALID_DATA` for the invalid documents and the
+        workflow does not start.
+
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: workflow_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/:{object_name}/:{object_record_id}/actions:
+    get:
+      tags:
+        - Object Lifecycle & Workflows > Object Record User Actions
+      summary: Retrieve Object Record User Actions
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Object_Record_Lifecycle_Actions
+
+
+
+        Retrieve all available user actions that can be initiated on a specific
+        object record which:
+
+
+        * The authenticated user has permissions to view or initiate
+
+        * Can be initiated through the API
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: loc
+          in: query
+          schema:
+            type: boolean
+          description: >
+            Optional: When true, retrieves localized (translated) strings for
+            the label.
+          example: 'true'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_record_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/:{object_name}/:{object_record_id}/actions/:{action_name}:
+    get:
+      tags:
+        - Object Lifecycle & Workflows > Object Record User Actions
+      summary: Retrieve Object User Actions Details
+      description: >-
+        https://developer.veevavault.com/api/25.1/#retrieve-object-user-action-details
+
+
+        Once you’ve retrieved the available user actions, use this request to
+        retrieve the details for a specific user action.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_record_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: action_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Object Lifecycle & Workflows > Object Record User Actions
+      summary: Initiate Object Action on a Single Record
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Initiate_Object_Record_Lifecycle_Action
+
+
+
+        Use this request to initiate an action on a specific object record.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_record_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: action_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/:{object_name}/actions/:{action_name}:
+    post:
+      tags:
+        - Object Lifecycle & Workflows > Object Record User Actions
+      summary: Initiate Object Action on Multiple Records
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Bulk_Initiate_Action
+
+
+        Use this request to initiate an object user action on multiple records.
+        Maximum 500 records per batch.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: action_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/objectworkflows/actions:
+    get:
+      tags:
+        - Object Lifecycle & Workflows > Multi-Record Workflows
+      summary: Retrieve All Multi-Record Workflows
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Multi_Record_Workflows
+
+
+
+        Retrieve all available multi-record workflows which:
+
+
+        * The authenticated user has permissions to view or initiate
+
+        * Can be initiated through the API
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/objectworkflows/actions/:workflow_name:
+    get:
+      tags:
+        - Object Lifecycle & Workflows > Multi-Record Workflows
+      summary: Retrieve Multi-Record Workflow Details
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Multi_Record_Workflow_Details
+
+
+
+        Retrieves the fields required to initiate a specific multi-record
+        workflow.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Object Lifecycle & Workflows > Multi-Record Workflows
+      summary: Initiate Multi-Record Workflow
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Initiate_Multi_Record_Workflow
+
+
+
+        Initiate a multi-record workflow on a set of records. If any record is
+        not in the relevant state or does not meet configured field conditions,
+        the API returns `INVALID_DATA` for the invalid records and the workflow
+        does not start.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/users:
+    post:
+      tags:
+        - Users > Create Users
+      summary: Create Multiple Users
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Bulk_Users_API
+
+
+
+        **Note:** Beginning in v18.1, Admins create and manage users with
+        <code>user__sys</code> object records. Unless you are creating
+        cross-domain users or adding users to a domain without assigning Vault
+        membership, we strongly recommend using the <a
+        href="https://developer.veevavault.com/api/24.3#Create_User_Object_Record">Create
+        Object Records</a> endpoint to create new users.
+
+
+        Create new users and assign them to Vaults in bulk. You can also add
+        multiple existing users as cross-domain users.
+
+
+        * The maximum input file size is 1GB.
+
+        * The values in the input must be UTF-8 encoded.
+
+        * CSVs must follow the <a href
+        ="https://datatracker.ietf.org/doc/html/rfc4180">standard format.</a>
+
+        * The maximum batch size is 500.
+
+        * If you want to add profile pictures, you must upload these to the <a
+        href="https://developer.veevavault.com/docs/#FTP">file staging
+        server</a>.
+
+
+        #### Headers
+
+
+        |Name          |Description                                |
+
+        |:-------------|:------------------------------------------|
+
+        |`Content-Type`|`application/json` or `text/csv`|
+
+        |`Accept`|`application/json` (default) or `text/csv`|
+
+
+        #### Body Parameters
+
+
+        Prepare a JSON or CSV input file. You may add values to any other
+        editable user field, unless you are are adding a cross-domain user. See
+        <a
+        href="https://developer.veevavault.com/api/24.3#Retrieve_All_Users">Retrieve
+        Users</a> for all possible values. Using only the required fields will
+        add users to your domain but will not assign them to individual Vaults
+        within your domain. See Vault Membership below.
+
+
+        |Name    |Description                                       |
+
+        |:-------|:-------------------------------------------------|
+
+        |`user_name__v`|The user’s Vault username (login credential). For
+        example, `ewoodhouse@veepharm.com`|
+
+        |`user_first_name__v`|The user's first name.|
+
+        |`user_last_name__v`|The user's last name.|
+
+        |`user_email__v`|The user's email address.|
+
+        |`user_timezone__v`|The user's time zone. Retrieve values from <a
+        href="https://developer.veevavault.com/api/24.3#Retrieve_All_Users">Retrieve
+        Users</a>.|
+
+        |`user_locale__v`|The user's location. Retrieve values from <a
+        href="https://developer.veevavault.com/api/24.3#Retrieve_All_Users">Retrieve
+        Users</a>.|
+
+        |`security_policy_id__v`|The user's security policy. Retrieve values
+        from <a
+        href="https://developer.veevavault.com/api/24.3#Retrieve_All_Security_Policies">Retrieve
+        All Security Policies</a>.|
+
+        |`user_language__v`|The user's preferred language. Retrieve values from
+        <a
+        href="https://developer.veevavault.com/api/24.3#Retrieve_All_Users">Retrieve
+        Users</a>.|
+
+        |`file`|Optional: The file path of a profile picture from the file
+        staging server. Must be JPG, PNG, or GIF, and less than 10MB in size.
+        Vault automatically resizes images to 64 x 64 pixels and removes the
+        animations from GIFs. Note that when you upload or change a user's
+        profile image, the change applies across the entire domain and will be
+        visible in all Vaults where user has membership.|
+
+        |`domain`|Optional: If you set this to `true`, the user will not be
+        assigned to a Vault.|
+
+        |`security_profile__v`|Optional: The user’s security profile. If
+        omitted, default value is `document_user__v`.|
+
+        |`license_type__v`|Optional: The user’s license type. If omitted,
+        default value is `full__v`.|
+
+        |`vault_membership`|Optional: Use this field to assign a user to
+        individual Vaults within your domain. This is required to create
+        cross-domain users. See below for how to configure.|
+
+        |`app_licensing`|Optional: Use this field to assign a user to individual
+        applications within your Vault. See below for how to configure.|
+
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - Users > Update Users
+      summary: Update Multiple Users
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Update_Multiple_Users
+
+
+
+        **Note:** Beginning in v18.1, Admins create and manage users with
+        <code>user__sys</code> object records. Unless you are updating
+        domain-only users, we strongly recommend using the <a
+        href="#Update_Object_Record">Update Object Records</a> endpoint to
+        update users.
+
+
+        Update information for multiple users at once.
+
+
+        * The maximum input file size is 1GB.
+
+        * The values in the input must be UTF-8 encoded.
+
+        * CSVs must follow the <a
+        href="https://datatracker.ietf.org/doc/html/rfc4180">standard
+        format</a>.
+
+        * The maximum batch size is 500.
+
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/users/:{id}:
+    put:
+      tags:
+        - Users > Update Users
+      summary: Update Single User
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Update_Single_User
+
+
+
+        **Note:** Beginning in v18.1, Admins create and manage users with
+        <code>user__sys</code> object records. Unless you are updating
+        domain-only users, we strongly recommend using the <a
+        href="#Update_Object_Record">Update Object Records</a> endpoint to
+        update users.
+
+
+        Update information for a single user. To update information for multiple
+        users, see <a
+        href="https://developer.veevavault.com/api/24.3#Retrieve_All_Users">Retrieve
+        All Users</a>.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    get:
+      tags:
+        - Users
+      summary: Retrieve User
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Retrieve_User
+
+
+        **Note:** This endpoint retrieves user records at the domain level.
+        Beginning in v18.1, Admins create and manage users with
+        <code>user__sys</code> object records. We strongly recommend using the
+        <a
+        href="https://developer.veevavault.com/api/25.1/#Retrieve_Object_Record">Retrieve
+        Object Record</a> endpoint to retrieve a <code>user__sys</code> record.
+
+
+        Retrieve information for one user. To get information for all users, see
+        <a
+        href="https://developer.veevavault.com/api/25.1/#Retrieve_All_Users">Retrieve
+        All Users</a>
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: exclude_vault_membership
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Set to true to omit vault_membership fields. If you don’t
+            need these fields, this may increase performance. If omitted,
+            vault_membership fields are included in the response.
+        - name: exclude_app_licensing
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Set to true to omit app_licensing fields. If you don’t
+            need these fields, this may increase performance. If omitted,
+            app_licensing fields are included in the response.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/objects/users:
+    get:
+      tags:
+        - Users
+      summary: Retrieve User Metadata
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Retrieve_User_Metadata
+
+
+        **Note:** This endpoint retrieves user metadata at the domain level.
+        Beginning in v18.1, Admins create and manage users with
+        <code>user__sys</code> object records. We strongly recommend using the
+        <a
+        href="https://developer.veevavault.com/api/25.1/#Retrieve_Object_Metadata">Retrieve
+        Object Metadata</a> endpoint to retrieve <code>user__sys</code>
+        metadata.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/users/:
+    get:
+      tags:
+        - Users
+      summary: Retrieve All Users
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Retrieve_All_Users
+
+
+        **Note:** This endpoint retrieves user records at the domain level.
+        Beginning in v18.1, Admins create and manage users with
+        <code>user__sys</code> object records. We strongly recommend using the
+        <a
+        href="https://developer.veevavault.com/api/25.1/#Retrieve_Object_Record_Collection">Retrieve
+        Object Record Collection</a> endpoint to retrieve <code>user__sys</code>
+        records.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: vaults
+          in: query
+          schema:
+            type: string
+          description: Retrieve all users assigned to all Vaults in your domain.
+          example: all
+        - name: vaults
+          in: query
+          schema:
+            type: string
+          description: >-
+            Retrieve all users assigned to all Vaults in your domain except for
+            the Vault in which the request is made.
+          example: '-1'
+        - name: vaults
+          in: query
+          schema:
+            type: string
+          description: >-
+            To retrieve users assigned only to specific Vaults, enter a
+            comma-separated list of Vault IDs. For example, `3003,4004,5005`. 
+          example: 3003,4004,5005
+        - name: exclude_vault_membership
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Set to false to include vault_membership fields. If true
+            or omitted, vault_membership fields are not included in the
+            response.
+        - name: exclude_app_licensing
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Set to false to include app_licensing fields. If true or
+            omitted, app_licensing fields are not included in the response.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/users/:{user_id}:
+    delete:
+      tags:
+        - Users
+      summary: Disable User
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Disable_User
+
+
+
+        Disable a user in a specific Vault or disable a user in all Vaults in
+        the domain.
+
+
+        **Note:** This endpoint disables users at the domain level. Beginning in
+        v18.1, Admins create and manage users with <code>user__sys</code> object
+        records. To disable users in an individual Vault, use the single or bulk
+        <a
+        href="https://developer.veevavault.com/api/24.3#Initiate_Object_Record_Lifecycle_Action">Initiate
+        Object Action</a> endpoint to initiate the <em>Make User Inactive</em>
+        action on the desired records.
+
+
+        #### Permissions
+
+
+        System Admins and Vault Owners can update users in the Vaults where they
+        have administrative access. System Admins who are also Domain Admins
+        have an unrestricted access to users across all Vaults in the domain.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: domain
+          in: query
+          schema:
+            type: boolean
+          description: >-
+            When true, this disables the user account in all vaults in the
+            domain.
+          example: 'true'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: user_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/users/me/password:
+    post:
+      tags:
+        - Users
+      summary: Change My Password
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Change_User_Password
+
+
+        Change the password for the currently authenticated user.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/users/:{user_id}/vault_membership/:{vault_id}:
+    put:
+      tags:
+        - Users
+      summary: Update Vault Membership
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Update_Vault_Membership
+
+
+
+        Use this request to:
+
+
+        * Assign an existing user to a Vault in your domain.
+
+        * Remove (disable) an existing user from a Vault in your domain.
+
+        * Update the security profile and license type of an existing user.
+
+
+        You cannot use this request to:
+
+
+        * Create a new user. See <a
+        href="https://developer.veevavault.com/api/24.3#Create_User_Object_Record">Create
+        Object Records</a>.
+
+        * Update other user profile information. See <a
+        href="https://developer.veevavault.com/api/24.3#Update_Object_Record">Update
+        Object Records</a>.
+
+
+        Additional information:
+
+
+        * For a list of user fields and properties, see <a
+        href="https://developer.veevavault.com/api/24.3#Retrieve_All_Users">Retrieve
+        Users</a>.
+
+        * Learn about <a
+        href="https://platform.veevavault.help/en/lr/953">Creating & Managing
+        Users</a> and <a
+        href="https://platform.veevavault.help/en/lr/15127">Managing Users
+        Across Vaults</a> in Vault Help.
+
+
+        #### Permissions
+
+
+        System Admins and Vault Owners can update users in the Vaults where they
+        have administrative access. System Admins who are also Domain Admins
+        have an unrestricted access to users across all Vaults in the domain.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: user_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: vault_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/licenses:
+    get:
+      tags:
+        - Users
+      summary: Retrieve Application License Usage
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Retrieve_Application_License_Usage](https://developer.veevavault.com/api/25.1/#Retrieve_Application_License_Usage)
+
+
+        Retrieve your current license usage compared to the licenses that your
+        organization has purchased. This information is similar to the
+        information displayed in the Vault UI from **Admin > Settings > General
+        Settings**.
+
+
+        Some Vaults use multiple applications, for example, a RIM Vault with
+        Submissions and Registrations. In these Vaults, users have a license
+        value for each application they can access. Application licensing allows
+        Vault to track available licenses at the application level, but does not
+        control a user’s access in most Vaults. A user assigned to multiple
+        applications will use one (1) application license per application. Learn
+        more about [Application Licenses in Vault
+        Help](https://platform.veevavault.help/en/lr/5721/).
+
+
+        #### Example Response
+
+
+        ``` json
+
+        {
+            "responseStatus": "SUCCESS",
+            "doc_count": {
+                "licensed": 4000,
+                "used": 2380
+            },
+            "applications": [
+                {
+                    "application_name": "pm_promomats__v",
+                    "user_licensing": {
+                        "full__v": {
+                            "licensed": 500,
+                            "used": 491,
+                            "shared": false
+                        },
+                        "external__v": {
+                            "licensed": 100,
+                            "used": 67,
+                            "shared": false
+                        },
+                        "read_only__v": {
+                            "licensed": 100,
+                            "used": 28,
+                            "shared": false
+                        }
+                    }
+                },
+                {
+                    "application_name": "pm_multichannel__v",
+                    "user_licensing": {
+                        "full__v": {
+                            "licensed": 500,
+                            "used": 441,
+                            "shared": false
+                        },
+                        "external__v": {
+                            "licensed": 0,
+                            "used": 0,
+                            "shared": false
+                        },
+                        "read_only__v": {
+                            "licensed": 0,
+                            "used": 0,
+                            "shared": false
+                        }
+                    }
+                }
+            ]
+        }
+
+         ```
+
+        #### Response Details
+
+
+        The response contains the following application license details:
+
+
+        | Name | Description |
+
+        | --- | --- |
+
+        | `doc_count` | PromoMats and Veeva Medical only: The number of document
+        views across all users with view-based license type against a
+        pre-purchased set of views for the Vault. Learn more about [view-based
+        user licenses in Vault
+        Help](https://platform.veevavault.help/en/lr/5721/). |
+
+        | `application_name` | The API name of this application license, for
+        example, `pm_multichannel__v`. |
+
+        | `user_licensing` | An array of the available application licenses for
+        the given `application_name`. |
+
+        | `user_licensing.licensed` | The maximum number of users who can be
+        assigned to this application license. For example, if the `full__v`
+        application license has a `licensed` value of `50`, you can assign this
+        license to a maximum of 50 users. |
+
+        | `user_licensing.used` | The number of users currently assigned to this
+        application license. To determine the number of application licenses
+        available for assignment, subtract `used` from `licensed`. For example,
+        if your application license has a `licensed` value of `50` and a `used`
+        value of `40`, you can assign 10 more users to this application license.
+        |
+
+        | `user_licensing.shared` | Indicates if this user license is shared. |
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/users/:{id}/permissions:
+    get:
+      tags:
+        - Users
+      summary: Retrieve User Permissions
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_User_Permissions
+
+
+
+        Retrieve all object and object field permissions (read, edit, create,
+        delete) assigned to a specific user.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: filter
+          in: query
+          schema:
+            type: string
+          description: >-
+            Filter the results to show only one specific name__v, which is in
+            the format object.{object name}.{object or field}_actions. Wildcards
+            are not supported. See example below.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/users/me/permissions:
+    get:
+      tags:
+        - Users
+      summary: Retrieve My User Permissions
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_My_User_Permissions
+
+
+
+        Retrieve all object and object field permissions (read, edit, create,
+        delete) assigned to the currently authenticated user.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: filter
+          in: query
+          schema:
+            type: string
+          description: >-
+            Filter the results to show only one specific name__v, which is in
+            the format object.{object name}.{object or field}_actions. Wildcards
+            are not supported. See example below.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/scim/v2/ServiceProviderConfig:
+    get:
+      tags:
+        - SCIM > Discovery Endpoints
+      summary: Retrieve SCIM Provider
+      description: >+
+        https://developer.veevavault.com/api/25.1/#SCIM_ProInformationvider_Info
+
+
+
+        Retrieve a JSON that describes the SCIM specification features available
+        on the currently authenticated Vault.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/scim+json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/scim/v2/Schemas:
+    get:
+      tags:
+        - SCIM > Discovery Endpoints
+      summary: Retrieve All SCIM Schema Information
+      description: >+
+        https://developer.veevavault.com/api/25.1/#SCIM_Retrieve_Schemas
+
+
+
+        Retrieve information about all SCIM schema specifications supported by a
+        Vault SCIM service provider.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/scim+json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/scim/v2/Schemas/:{id}:
+    get:
+      tags:
+        - SCIM > Discovery Endpoints
+      summary: Retrieve Single SCIM Schema Information
+      description: >+
+        https://developer.veevavault.com/api/25.1/#SCIM_Retrieve_Schema
+
+
+
+        Retrieve information about a single SCIM schema specification supported
+        by a Vault SCIM service provider.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/scim+json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/scim/v2/ResourceTypes:
+    get:
+      tags:
+        - SCIM > Discovery Endpoints
+      summary: Retrieve All SCIM Resource Types
+      description: >+
+        https://developer.veevavault.com/api/25.1/#SCIM_Retrieve_Resource_Types
+
+
+
+        Retrieve the types of SCIM resources available. Each resource type
+        defines the endpoints, the core schema URI that defines the resource,
+        and any supported schema extensions.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/scim+json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/scim/v2/ResourceTypes/:{type}:
+    get:
+      tags:
+        - SCIM > Discovery Endpoints
+      summary: Retrieve Single SCIM Resource Type
+      description: >+
+        https://developer.veevavault.com/api/25.1/#SCIM_Retrieve_Resource_Type
+
+
+
+        Retrieve a single SCIM resource type. Defines the endpoints, the core
+        schema URI which defines this resource, and any supported schema
+        extensions.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/scim+json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: type
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/scim/v2/Users:
+    get:
+      tags:
+        - SCIM > Users
+      summary: Retrieve All Users with SCIM
+      description: |+
+        https://developer.veevavault.com/api/25.1/#SCIM_Retrieve_Users
+
+
+        Retrieve all users with SCIM.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/scim+json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: filter
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Filter for a specific attribute value. Must be in the
+            format {attribute} eq "{value}". For example, to filter for a
+            particular user name, userName eq "john". Complex expressions are
+            not supported, and eq is the only supported operator.
+        - name: attributes
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Include specified attributes only. Enter multiple values
+            in a comma separated list. For example, to include only user name
+            and email in the response, attributes=userName,emails. Note that the
+            schemas and id attributes are always returned.
+        - name: excludedAttributes
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Exclude specific attributes from the response. Enter
+            multiple values in a comma separated list. For example, to exclude
+            user name and email from the response,
+            excludedAttributes=userName,emails. Note that the schemas and id
+            attributes are always returned and cannot be excluded.
+        - name: sortBy
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Specify an attribute or sub-attribute to order the
+            response. For example, you can sort by the displayName attribute, or
+            the name.familyName sub-attribute. If omitted, the response is
+            sorted by id. Note that the following attributes are not supported:
+
+            securityPolicy
+
+            securityProfile
+
+            locale
+
+            preferredLanguage
+        - name: sortOrder
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Specify the order in which the sortBy parameter is
+            applied. Allowed values are ascending or descending. If omitted,
+            defaults to ascending.
+        - name: count
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Specify the number of query results per page, for example,
+            10. Negative values are treated as 0, and 0 returns no results
+            except for totalResults. If omitted, defaults to 1000.
+        - name: startIndex
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Specify the index of the first result. For example, 10
+            would omit the first 9 results and begin on result 10. Omission,
+            negative values, and 0 is treated as 1.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - SCIM > Users
+      summary: Create User with SCIM
+      description: |+
+        https://developer.veevavault.com/api/25.1/#SCIM_Create_User
+
+
+        Create a user with SCIM.
+
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                schemas:
+                  - urn:ietf:params:scim:schemas:extension:veevavault:2.0:User
+                  - urn:ietf:params:scim:schemas:core:2.0:User
+                userName: AbigailSmith@veepharm.com
+                emails:
+                  - value: abigail.smith@veepharm.com
+                    type: work
+                name:
+                  familyName: Smith
+                  givenName: Abigail
+                preferredLanguage: en
+                locale: en_US
+                timezone: America/Los_Angeles
+                urn:ietf:params:scim:schemas:extension:veevavault:2.0:User:
+                  securityProfile:
+                    value: system_admin__v
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/scim+json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/scim+json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/scim/v2/Users/:{id}:
+    get:
+      tags:
+        - SCIM > Users
+      summary: Retrieve Single User with SCIM
+      description: |+
+        https://developer.veevavault.com/api/25.1/#SCIM_Retrieve_User
+
+
+        Retrieve a specific user with SCIM.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/scim+json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: filter
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Filter for a specific attribute value. Must be in the
+            format {attribute} eq "{value}". For example, to filter for a
+            particular user name, userName eq "john". Complex expressions are
+            not supported, and eq is the only supported operator.
+        - name: attributes
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Include specified attributes only. Enter multiple values
+            in a comma separated list. For example, to include only user name
+            and email in the response, attributes=userName,emails. Note that the
+            schemas and id attributes are always returned.
+        - name: excludedAttributes
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Exclude specific attributes from the response. Enter
+            multiple values in a comma separated list. For example, to exclude
+            user name and email from the response,
+            excludedAttributes=userName,emails. Note that the schemas and id
+            attributes are always returned and cannot be excluded.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - SCIM > Users
+      summary: Update User with SCIM
+      description: |+
+        https://developer.veevavault.com/api/25.1/#SCIM_Update_User
+
+
+        Update fields values on a single user with SCIM.
+
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                schemas:
+                  - urn:ietf:params:scim:schemas:extension:veevavault:2.0:User
+                  - urn:ietf:params:scim:schemas:core:2.0:User
+                userName: AbigailSmith@veepharm.com
+                name:
+                  familyName: Smith
+                  givenName: Abigail
+                urn:ietf:params:scim:schemas:extension:veevavault:2.0:User:
+                  securityProfile:
+                    value: system_admin__v
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/scim+json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/scim+json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/scim/v2/Me:
+    get:
+      tags:
+        - SCIM > Users
+      summary: Retrieve Current User with SCIM
+      description: |+
+        https://developer.veevavault.com/api/25.1/#SCIM_Retrieve_Me
+
+
+        Retrieve the currently authenticated user with SCIM.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/scim+json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: attributes
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Include specified attributes only. Enter multiple values
+            in a comma separated list. For example, to include only user name
+            and email in the response, attributes=userName,emails. Note that the
+            schemas and id attributes are always returned.
+        - name: excludedAttributes
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Exclude specific attributes from the response. Enter
+            multiple values in a comma separated list. For example, to exclude
+            user name and email from the response,
+            excludedAttributes=userName,emails. Note that the schemas and id
+            attributes are always returned and cannot be excluded.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - SCIM > Users
+      summary: Update Current User with SCIM
+      description: |+
+        https://developer.veevavault.com/api/25.1/#SCIM_Update_Me
+
+
+        Update the currently authenticated user with SCIM.
+
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                schemas:
+                  - urn:ietf:params:scim:schemas:extension:veevavault:2.0:User
+                  - urn:ietf:params:scim:schemas:core:2.0:User
+                name:
+                  familyName: Murray
+                  givenName: Megan
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/scim+json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/scim+json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: attributes
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Include specified attributes only. Enter multiple values
+            in a comma separated list. For example, to include only user name
+            and email in the response, attributes=userName,emails. Note that the
+            schemas and id attributes are always returned.
+        - name: excludedAttributes
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Exclude specific attributes from the response. Enter
+            multiple values in a comma separated list. For example, to exclude
+            user name and email from the response,
+            excludedAttributes=userName,emails. Note that the schemas and id
+            attributes are always returned and cannot be excluded.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/scim/v2/:{type}:
+    get:
+      tags:
+        - SCIM
+      summary: Retrieve SCIM Resources
+      description: >+
+        https://developer.veevavault.com/api/25.1/#SCIM_Retrieve_Resource_Type_Info
+
+
+
+        Retrieve a single SCIM resource type. Defines the endpoints, the core
+        schema URI which defines this resource, and any supported schema
+        extensions.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/scim+json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: filter
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Filter for a specific attribute value. Must be in the
+            format {attribute} eq "{value}". For example, to filter for a
+            particular user name, userName eq "john". Complex expressions are
+            not supported, and eq is the only supported operator.
+        - name: attributes
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Include specified attributes only. Enter multiple values
+            in a comma separated list. For example, to include only user name
+            and email in the response, attributes=userName,emails. Note that the
+            schemas and id attributes are always returned.
+        - name: excludedAttributes
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Exclude specific attributes from the response. Enter
+            multiple values in a comma separated list. For example, to exclude
+            user name and email from the response,
+            excludedAttributes=userName,emails. Note that the schemas and id
+            attributes are always returned and cannot be excluded.
+        - name: sortBy
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Specify an attribute or sub-attribute to order the
+            response. For example, you can sort by the displayName attribute, or
+            the name.familyName sub-attribute. If omitted, the response is
+            sorted by id. Note that the following attributes are not supported:
+
+            securityPolicy
+
+            securityProfile
+
+            locale
+
+            preferredLanguage
+        - name: sortOrder
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Specify the number of query results per page, for example,
+            10. Negative values are treated as 0, and 0 returns no results
+            except for totalResults. If omitted, defaults to 1000.
+        - name: startIndex
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Specify the index of the first result. For example, 10
+            would omit the first 9 results and begin on result 10. Omission,
+            negative values, and 0 is treated as 1.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: type
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/scim/v2/:{type}/:{id}:
+    get:
+      tags:
+        - SCIM
+      summary: Retrieve Single SCIM Resource
+      description: |+
+        https://developer.veevavault.com/api/25.1/#SCIM_Retrieve_Single_Resource
+
+
+        Retrieve a single SCIM resource.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/scim+json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: attributes
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Include specified attributes only. Enter multiple values
+            in a comma separated list. For example, to include only user name
+            and email in the response, attributes=userName,emails. Note that the
+            schemas and id attributes are always returned.
+        - name: excludedAttributes
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: Exclude specific attributes from the response. Enter
+            multiple values in a comma separated list. For example, to exclude
+            user name and email from the response,
+            excludedAttributes=userName,emails. Note that the schemas and id
+            attributes are always returned and cannot be excluded.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: type
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/objects/groups:
+    get:
+      tags:
+        - Groups
+      summary: Retrieve Group Metadata
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Group_Metadata
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/groups:
+    get:
+      tags:
+        - Groups
+      summary: Retrieve All Groups
+      description: "[https://developer.veevavault.com/api/25.1/#Retrieve_All_Groups](https://developer.veevavault.com/api/25.1/#Retrieve_All_Groups)\n\nRetrieve all groups except Auto Managed groups. You can retrieve Auto Managed groups using the\_[Retrieve Auto Managed Groups](https://developer.veevavault.com/api/25.1/#Retrieve_Auto_Managed_Groups)\_endpoint."
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: includeImplied
+          in: query
+          schema:
+            type: string
+          description: >-
+            When true, the response includes the implied_members__v field. These
+            users are automatically added to the group when their
+            security_profiles__v are added to the group. If omitted, the
+            response includes only the members__v field. These users are
+            individually added to a group by an Admin.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Groups
+      summary: 'Create Group '
+      description: https://developer.veevavault.com/api/25.1/#Create_Group
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/groups/auto:
+    get:
+      tags:
+        - Groups
+      summary: Retrieve Auto Managed Groups
+      description: "[https://developer.veevavault.com/api/25.1/#Retrieve_All_Groups](https://developer.veevavault.com/api/25.1/#Retrieve_All_Groups)\n\nRetrieve all Auto Managed groups. Learn more about\_[Auto Managed groups](https://platform.veevavault.help/en/lr/3200#auto-managed) in Vault Help."
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: limit
+          in: query
+          schema:
+            type: string
+          description: >
+            Paginate the results by specifying the maximum number of records per
+            page in the response. This can be any value between 1 and 1000. If
+            omitted, defaults to 1000.
+        - name: offset
+          in: query
+          schema:
+            type: string
+          description: >-
+            Paginate the results displayed per page by specifying the amount of
+            offset from the entry returned. For example, if you are viewing the
+            first 50 results (page 1) and want to see the next page, set this to
+            offset=51. If omitted, defaults to 0.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/groups/:{group_id}:
+    get:
+      tags:
+        - Groups
+      summary: Retrieve Group
+      description: https://developer.veevavault.com/api/25.1/#Retrieve_Group
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: includeImplied
+          in: query
+          schema:
+            type: boolean
+          description: >-
+            When true, the response includes the implied_members__v field. These
+            users are automatically added to the group when their
+            security_profiles__v are added to the group. When not used, the
+            response includes only the members__v field. These users are
+            individually added to a group by Admin.
+          example: 'true'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: group_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - Groups
+      summary: Update Group
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Update_Group
+
+
+        Update editable group field values. Add or remove group members and
+        security profiles.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: group_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Groups
+      summary: Delete Group
+      description: |-
+        https://developer.veevavault.com/api/25.1/#Delete_Group
+
+        Delete a user-defined group. You cannot delete system-managed groups.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: group_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/picklists:
+    get:
+      tags:
+        - Picklists
+      summary: Retrieve All Picklists
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Retrieve_All_Picklists
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/picklists/:{picklist_name}:
+    get:
+      tags:
+        - Picklists
+      summary: Retrieve Picklist Values
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Picklist_Values
+
+
+        Retrieve all available values configured on a picklist.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: picklist_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Picklists
+      summary: Create Picklist Values
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Create_Picklist_Values](https://developer.veevavault.com/api/25.1/#Create_Picklist_Values)
+
+
+        Add new values to a picklist. You can add up to 2,000 values to any
+        picklist.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: picklist_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - Picklists
+      summary: Update Picklist Value Label
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Update_Picklist_Value_Label
+
+
+
+        Change a picklist value `label` (only). To change a picklist value
+        `name`, see the <a
+        href="https://developer.veevavault.com/api/24.3#Update_Picklist_Value_Name">next
+        section</a> below.
+
+
+        Use caution when editing picklist labels or names. When these attributes
+        are changed, they affect all existing document and object metadata that
+        refer to the picklist. For users in the UI who are accustomed to seeing
+        a particular selection, the changes may cause confusion. This may also
+        break existing integrations that access picklist values via the API.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: picklist_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/picklists/:{picklist_name}/:{picklist_value_name}:
+    put:
+      tags:
+        - Picklists
+      summary: Update Picklist Value
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Update_Picklist_Value_Name
+
+
+
+        Change a picklist value `name` or `status`. To change a picklist value
+        `label`, see <a
+        href="https://developer.veevavault.com/api/24.3#Update_Picklist_Value_Label">Update
+        Picklist Value Label</a>.
+
+
+        Use caution when editing picklist value names. When you change a
+        picklist value name, it may affect existing document and object metadata
+        that refer to the picklist. This may also break existing integrations
+        that access picklist values via the API.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: picklist_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: picklist_value_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Picklists
+      summary: Inactivate Picklist Value
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Delete_Picklist_Value
+
+
+        **Note:** If you need to inactivate a picklist value, it is best
+        practice to use <a
+        href="https://developer.veevavault.com/api/24.3#Update_Picklist_Value_Name">Update
+        Picklist Value</a>.
+
+
+        Inactivate a value from a picklist. This does not affect picklist values
+        that are already in use.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: picklist_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: picklist_value_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/edl_item__v/actions/createplaceholder:
+    post:
+      tags:
+        - Expected Document Lists
+      summary: Create a Placeholder from an EDL Item
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Create_Placeholder_from_EDL_Item
+
+
+
+        Create a placeholder from an EDL item. Learn about working with <a
+        href="https://platform.veevavault.help/en/lr/15087">Content Placeholders
+        in Vault Help</a>.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/composites/trees/:edl_hierarchy_or_template:
+    get:
+      tags:
+        - Expected Document Lists
+      summary: Retrieve All Root Nodes
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Root_Nodes
+
+
+
+        Retrieves all root EDL nodes and node metadata. Learn more about <a
+        href="https://platform.veevavault.help/en/lr/37472">EDL hierarchies in
+        Vault Help</a>.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/composites/trees/:edl_hierarchy_or_template/actions/listnodes:
+    post:
+      tags:
+        - Expected Document Lists
+      summary: Retrieve Specific Root Nodes
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Specific_Root_Nodes
+
+
+        Retrieves the root node ID for the given EDL record IDs.
+
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example: ''
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/composites/trees/edl_hierarchy__v/:{parent_node_id}/children:
+    get:
+      tags:
+        - Expected Document Lists
+      summary: Retrieve a Node's Children
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Node_Children
+
+
+
+        Given an EDL node ID, retrieves immediate children (not grandchildren)
+        of that node. Learn more about EDL hierarchies in <a
+        href="https://platform.veevavault.help/en/lr/37472">Vault Help</a>.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: parent_node_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - Expected Document Lists
+      summary: Update Node Order
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Update_Node_Order
+
+
+        Given an EDL parent node, update the order of its children.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: parent_node_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/edl_matched_documents/batch/actions/add:
+    post:
+      tags:
+        - Expected Document Lists
+      summary: Add EDL Matched Documents
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Add_EDL_Matched_Document](https://developer.veevavault.com/api/25.1/#Add_EDL_Matched_Document)
+
+
+        Add matched documents to EDL Items. You must have a security profile
+        that grants the _Application: EDL Matching: Edit Document Matches_
+        permission, and EDL Matched Document APIs must be enabled in your Vault.
+        To enable this feature, contact <a
+        href="https://support.veeva.com/hc/en-us">Veeva Support</a>. The
+        `edl_status__v` field must also be enabled for the object type of the
+        specified EDL Item.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                - id: 0EI000000003001
+                  document_id: '21'
+                  major_version_number__v: 1
+                  minor_version_number__v: 0
+                  lock: true
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/edl_matched_documents/batch/actions/remove:
+    post:
+      tags:
+        - Expected Document Lists
+      summary: Remove EDL Matched Documents
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Remove_EDL_Matched_Documents](https://developer.veevavault.com/api/25.1/#Remove_EDL_Matched_Documents)
+
+
+        Remove manually matched documents from EDL Items. You must have a
+        security profile that grants the _Application: EDL Matching: Edit
+        Document Matches_ permission, and EDL Matched Document APIs must be
+        enabled in your Vault. To enable this feature, contact <a
+        href="https://support.veeva.com/hc/en-us">Veeva Support</a>. The
+        `edl_status__v` field must also be enabled for the object type of the
+        specified EDL Item.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                - id: 0EI000000003001
+                  document_id: '21'
+                  major_version_number__v: 1
+                  minor_version_number__v: 0
+                  remove_locked: true
+                - id: 0EI000000003001
+                  document_id: '22'
+                  major_version_number__v: 0
+                  minor_version_number__v: 1
+                  remove_locked: true
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/objects/securitypolicies:
+    get:
+      tags:
+        - Security Policies
+      summary: Retrieve Security Policy Metadata
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Retrieve_Security_Policy_Metadata
+
+
+        Retrieve the metadata associated with the security policy object.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/securitypolicies:
+    get:
+      tags:
+        - Security Policies
+      summary: Retrieve All Security Policies
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Retrieve_All_Security_Policies
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/securitypolicies/:{security_policy_name}:
+    get:
+      tags:
+        - Security Policies
+      summary: Retrieve Security Policy
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Retrieve_Single_Security_Policy
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: security_policy_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/domain:
+    get:
+      tags:
+        - Domain Information
+      summary: Retrieve Domain Information
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Domain_Vaults
+
+
+
+        Domain Admins can use this request to retrieve a list of all Vaults
+        currently in their domain.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: include_application
+          in: query
+          schema:
+            type: boolean
+          description: >-
+            To include Vault application type information in the response, set
+            include_application to true. If omitted, defaults to false and
+            application information is not included.
+          example: 'true'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/domains:
+    get:
+      tags:
+        - Domain Information
+      summary: Retrieve Domains
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Domains
+
+
+
+        Non-domain Admins can use this request to retrieve a list of all their
+        domains, including the domain of the current Vault. You can use this
+        data as a valid `domain` value when <a
+        href="https://developer.veevavault.com/api/24.3#Create_Refresh_Sandbox">creating
+        a sandbox Vault</a>.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/package:
+    post:
+      tags:
+        - Configuration Migration
+      summary: Export Package
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Export_Package_Config_Migration
+
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - Configuration Migration
+      summary: Import Package
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Import_Package_Config
+
+
+
+        Asynchronously import and validate a VPK package attached to this
+        request. On completion, Vault sends an email notification which includes
+        a link to the <a
+        href="https://platform.veevavault.help/en/lr/36919#validation-logs">validation
+        log</a>. For packages that include Vault Java SDK code, this checks code
+        compilation and restrictions in use of the JDK. For example, `new` is
+        not allowed for non-allowlisted classes. Learn more about <a
+        href="https://developer.veevavault.com/sdk/#Limits_Restrictions">Vault
+        Java SDK limits and restrictions</a>.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: multipart/form-data
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobject/vault_package__v/:{package_id}/actions/deploy:
+    post:
+      tags:
+        - Configuration Migration
+      summary: Deploy Package
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Deploy_Package_Config
+
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: package_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobject/vault_package__v/:{package_id}/actions/deploy/results:
+    get:
+      tags:
+        - Configuration Migration
+      summary: Retrieve Package Deploy Results
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Package_Deploy_Results
+
+
+
+        After Vault has finished processing the deploy job, use this request to
+        retrieve the results of the completed deployment.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: package_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/outbound_package__v/:{package_id}/dependencies:
+    get:
+      tags:
+        - Configuration Migration
+      summary: Retrieve Outbound Package Dependencies
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Dependencies_Config
+
+
+
+        Outbound packages only include configuration details for the included
+        components. Sometimes, a configuration for one component depends on
+        another component which you may not have explicitly specified.
+
+
+        With this API, you can retrieve all outstanding component dependencies
+        for an outbound package. You can then add these missing dependencies to
+        the package with the <a
+        href="https://developer.veevavault.com/api/24.3#Create_Object_Record">Create
+        Object Records API</a>.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: package_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/query/components:
+    post:
+      tags:
+        - Configuration Migration
+      summary: Component Definition Query
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Component_Definition_Query
+
+
+
+        Retrieve MDL definitions (`mdl_definition__v`) and JSON definitions
+        (`json_definition__v`) of Vault components using a VQL query on the
+        `vault_component__v` and `vault_package_component__v` query targets.
+        Learn more in the <a
+        href="https://developer.veevavault.com/vql/#Vault_Component_Definitions">VQL
+        documentation</a>.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/vault/actions/compare:
+    post:
+      tags:
+        - Configuration Migration
+      summary: Vault Compare
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Vault_Compare
+
+
+
+        Compare the configuration of two different Vaults. The Vault you make
+        the request in is the source Vault, and the target Vault for the
+        comparison is listed in the body. Learn more about <a
+        href="https://platform.veevavault.help/en/lr/40902">Vault Compare in
+        Vault Help</a>.
+
+
+        The user who makes the request must be a cross-domain user and must have
+        access to the `vault_component__v` in both Vaults. Learn more about <a
+        href="https://platform.veevavault.help/en/lr/38996">cross-domain users
+        in Vault Help</a>.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/vault/actions/configreport:
+    post:
+      tags:
+        - Configuration Migration
+      summary: Vault Configuration Report
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Vault_Configuration_Report](https://developer.veevavault.com/api/25.1/#Vault_Configuration_Report)
+
+
+        Generate an Excel™ report containing configuration information for a
+        Vault. Users must have the Vault Configuration Report permission to use
+        this API.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/package/actions/validate:
+    post:
+      tags:
+        - Configuration Migration
+      summary: Validate Inbound Package
+      description: >-
+        https://developer.veevavault.com/api/25.1/#validate_inbound_package
+
+
+        Validate an imported VPK package before deploying it to your Vault. The
+        validation response includes information on dependent components and
+        whether they exist in the package or in your Vault. You can then add
+        missing dependencies to the package in the source Vault before
+        re-importing and deploying it to your target Vault. Learn more about <a
+        href="https://platform.veevavault.help/en/lr/36919#validation-logs">validation
+        logs in Vault Help</a>.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/configuration_mode/actions/enable:
+    post:
+      tags:
+        - Configuration Migration
+      summary: Enable Configuration Mode
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Enable_Configuration_Mode](https://developer.veevavault.com/api/24.2/#Enable_Disable_Code)
+
+
+        Enable Configuration Mode in the currently authenticated Vault. When
+        enabled, Configuration Mode locks non-Admin users out of Vault. Vault
+        Owners and System Admins can still access Vault to [deploy configuration
+        migration
+        packages](https://developer.veevavault.com/api/24.2/#deploy-package) or
+        set up Dynamic Access Control (DAC).
+
+
+        Users with access to multiple Vaults can log in if at least one Vault in
+        the domain is not in Configuration Mode.
+
+
+        Learn more about [Configuration Mode in Vault
+        Help](https://quality.veevavault.help/en/lr/36928/).
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/configuration_mode/actions/disable:
+    post:
+      tags:
+        - Configuration Migration
+      summary: Disable Configuration Mode
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Disable_Configuration_Mode](https://developer.veevavault.com/api/25.1/#Disable)
+
+
+        Disable Configuration Mode in the currently authenticated Vault. When
+        you disable Configuration Mode, non-Admin users can now access Vault.
+
+
+        Learn more about [Configuration Mode in Vault
+        Help](https://quality.veevavault.help/en/lr/36928/).
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/sandbox/actions/buildproduction:
+    post:
+      tags:
+        - Sandbox Vaults > Pre-Production Vaults
+      summary: Build Production Vault
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Build_Production
+
+
+
+        Given a pre-production Vault, build a production Vault. This is
+        analogous to the *Build* action in the Vault UI. After building your
+        Vault, you can promote it to production.
+
+
+        You can build or rebuild the source Vault for a given pre-production
+        Vault no more than three times in a 24 hour period.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/sandbox/actions/promoteproduction:
+    post:
+      tags:
+        - Sandbox Vaults > Pre-Production Vaults
+      summary: Promote to Production
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Promote_Production
+
+
+
+        Given a built pre-production Vault, promote it to a production Vault.
+        This is analogous to the *Promote* action in the Vault UI.
+
+
+        You must build your pre-production Vault before you can promote it to
+        production.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/sandbox/snapshot:
+    post:
+      tags:
+        - Sandbox Vaults > Sandbox Snapshots
+      summary: Create Sandbox Snapshot
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Create_Snapshot](https://developer.veevavault.com/api/25.1/#Create_Snapshot)
+
+
+        Create a new snapshot for the indicated sandbox Vault.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    get:
+      tags:
+        - Sandbox Vaults > Sandbox Snapshots
+      summary: Retrieve Sandbox Snapshots
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Retrieve_Snapshots](https://developer.veevavault.com/api/25.1/#Retrieve_Snapshots)
+
+
+        Retrieve information about snapshots managed by the authenticated Vault.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/sandbox/snapshot/:{api_name}:
+    delete:
+      tags:
+        - Sandbox Vaults > Sandbox Snapshots
+      summary: Delete Sandbox Snapshot
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Delete_Snapshot](https://developer.veevavault.com/api/25.1/#Delete_Snapshot)
+
+
+        Delete a snapshot managed by the authenticated Vault. Deleted snapshots
+        cannot be recovered. Learn more about [deleting snapshots in Vault
+        Help](https://platform.veevavault.help/en/lr/535936/#delete).
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: api_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/sandbox/snapshot/:{api_name}/actions/update:
+    post:
+      tags:
+        - Sandbox Vaults > Sandbox Snapshots
+      summary: Update Sandbox Snapshot
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Update_Snapshot](https://developer.veevavault.com/api/25.1/#Update_Snapshot)
+
+
+        Recreate a snapshot for the same source sandbox Vault. This request
+        replaces the existing snapshot with the newly created one. Learn more
+        about [updating snapshots in Vault
+        Help](https://platform.veevavault.help/en/lr/535936/#update).
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: api_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/sandbox/snapshot/:{api_name}/actions/upgrade:
+    post:
+      tags:
+        - Sandbox Vaults > Sandbox Snapshots
+      summary: Upgrade Sandbox Snapshot
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Upgrade_Snapshot](https://developer.veevavault.com/api/25.1/#Upgrade_Snapshot)
+
+
+        Upgrade a sandbox snapshot to match the release version of the source
+        sandbox Vault.
+
+
+        Your request to upgrade a snapshot is only valid if the
+        `upgrade_status=Upgrade Available` or `Upgrade Required`. Use the
+        [Retrieve Sandbox
+        Snapshots](http://localhost:8400/api/25.1/#Retrieve_Snapshots) request
+        to obtain the `upgrade_status` of a snapshot.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: api_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/sandbox:
+    get:
+      tags:
+        - Sandbox Vaults
+      summary: Retrieve Sandboxes
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Retrieve_Sandboxes
+
+
+        Retrieve information about the sandbox Vaults for the authenticated
+        vault.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Sandbox Vaults
+      summary: Create or Refresh Sandbox
+      description: "[https://developer.veevavault.com/api/25.1/#Create_Refresh_Sandbox](https://developer.veevavault.com/api/25.1/#Create_Refresh_Sandbox)\n\nCreate a new sandbox for the currently authenticated Vault. Include the\_`source_snapshot`\_parameter in the request body to create a new sandbox from an existing\_[snapshot](https://developer.veevavault.com/api/25.1/#Sandbox_Snapshots).\n\nProviding a name which already exists will refresh the existing sandbox Vault. You can also\_[refresh a sandbox from a snapshot](https://developer.veevavault.com/api/25.1/#Refresh_Sandbox_from_Snapshot)."
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/sandbox/:vault_id:
+    get:
+      tags:
+        - Sandbox Vaults
+      summary: Retrieve Sandbox Details by ID
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Retrieve_Sandbox_Details_By_ID
+
+
+        Retrieve information about the sandbox Vaults for the authenticated
+        vault.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/sandbox/actions/recheckusage:
+    post:
+      tags:
+        - Sandbox Vaults
+      summary: Recheck Sandbox Usage Limit
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Recheck_Sandbox_Usage_Limit](https://developer.veevavault.com/api/25.1/#Recheck_Sandbox_Usage_Limit)
+
+
+        Recalculate the usage values of the sandbox Vaults for the authenticated
+        Vault. This action can be initiated up to three (3) times in a 24-hour
+        period. In the UI, this information is available in Admin > Settings.
+        Learn more about [viewing usage details in Vault
+        Help](https://platform.veevavault.help/en/lr/48988/#usage).
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example: ''
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/sandbox/batch/changesize:
+    post:
+      tags:
+        - Sandbox Vaults
+      summary: Change Sandbox Size
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Change_Sandbox_Size](https://developer.veevavault.com/api/25.1/#Change_Sandbox_Size)
+
+
+        Change the size of a sandbox Vault for the authenticated Vault. You can
+        initiate this action if there are sufficient allowances and the current
+        sandbox meets the data and user limits of the requested size. Learn more
+        about [sandbox sizes in Vault
+        Help](https://platform.veevavault.help/en/lr/48988/#sizes).
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example: ''
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/sandbox/entitlements/set:
+    post:
+      tags:
+        - Sandbox Vaults
+      summary: Set Sandbox Entitlements
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Set_Sandbox_Entitlements
+
+
+        Set new sandbox entitlements, including granting and revoking
+        allowances, for the given sandbox `name`.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/sandbox/:{vault_id}/actions/refresh:
+    post:
+      tags:
+        - Sandbox Vaults
+      summary: Refresh Sandbox from Snapshot
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Refresh_Sandbox_from_Snapshot](https://developer.veevavault.com/api/25.1/#Refresh_Sandbox_from_Snapshot)
+
+
+        Refresh a sandbox Vault in the currently authenticated Vault from an
+        existing
+        [snapshot](https://developer.veevavault.com/api/25.1/#Sandbox_Snapshots).
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: vault_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/sandbox/:{name}:
+    delete:
+      tags:
+        - Sandbox Vaults
+      summary: Delete Sandbox
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Delete_Sandbox](https://developer.veevavault.com/api/25.1/#Delete_Sandbox)
+
+
+        Delete a sandbox Vault. How often you can delete a Vault depends on its
+        size. Learn more about [deleting sandboxes in Vault
+        Help](https://platform.veevavault.help/en/lr/48988/#delete).
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/audittrail:
+    get:
+      tags:
+        - Logs > Audit
+      summary: Retrieve Audit Types
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Audit_Types
+
+
+        Retrieve all available audit types you have permission to access.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/metadata/audittrail/:{audit_trail_type}:
+    get:
+      tags:
+        - Logs > Audit
+      summary: Retrieve Audit Metadata
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Audit_Metadata
+
+
+
+        Retrieve all fields and their metadata for a specified audit trail or
+        log type.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: audit_trail_type
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/audittrail/:{audit_trail_type}:
+    get:
+      tags:
+        - Logs > Audit
+      summary: Retrieve Audit Details
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Audit_Details
+
+
+
+        Retrieve all audit details for a specific audit type. This request
+        supports optional parameters to narrow the results to a specified date
+        and time within the past 30 days.
+
+
+        You can run a full audit export with the same formatting as exports you
+        initiate in the UI once per day per audit type. To execute a full audit
+        export, set `all_dates` to true, leave `start_date` and `end_date`
+        blank, and set `format_result` to `csv`. When the job is complete, you
+        will receive an email containing links to a zipped file for each year.
+
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: start_date
+          in: query
+          schema:
+            type: string
+          description: >-
+            Specify a start date to retrieve audit information. This date cannot
+            be more than 30 days ago. Dates must be YYYY-MM-DDTHH:MM:SSZ format,
+            for example, 7AM on January 15, 2016 would use 2016-01-15T07:00:00Z.
+            If omitted, defaults to the last 30 days.
+        - name: end_date
+          in: query
+          schema:
+            type: string
+          description: >-
+            Specify an end date to retrieve audit information. This date cannot
+            be more than 30 days ago. Dates must be YYYY-MM-DDTHH:MM:SSZ format,
+            for example, 7AM on January 15, 2016 would use 2016-01-15T07:00:00Z.
+            If omitted, defaults to the last 30 days.
+        - name: all_dates
+          in: query
+          schema:
+            type: string
+          description: >-
+            Set to true to request audit information for all dates. You must
+            leave start_date and end_date blank when requesting an export of a
+            full audit trail.
+        - name: format_result
+          in: query
+          schema:
+            type: string
+          description: >-
+            To request a downloadable CSV file of your audit details, use csv.
+            The response contains a jobId to retrieve the job status, which
+            contains a link to download the CSV file. If omitted, the API
+            returns a JSON response and does not start a job. If all_dates is
+            true, this parameter is required.
+        - name: limit
+          in: query
+          schema:
+            type: string
+          description: >-
+            Paginate the results by specifying the maximum number of histories
+            per page in the response. This can be any value between 1 and 1000.
+            If omitted, defaults to 200.
+        - name: offset
+          in: query
+          schema:
+            type: string
+          description: >-
+            Paginate the results displayed per page by specifying the amount of
+            offset from the entry returned. For example, if you are viewing the
+            first 50 results (page 1) and want to see the next page, set this to
+            offset=51. If omitted, defaults to 0.
+        - name: objects
+          in: query
+          schema:
+            type: string
+          description: >-
+            This is an optional parameter when specifying object_audit_trail as
+            the {audit_trail_type}. Provide a comma-separated list of one or
+            more object names to retrieve their audit details. For example,
+            objects=product__v,country__v. If omitted, defaults to all objects.
+        - name: events
+          in: query
+          schema:
+            type: string
+          description: >-
+            This is an optional parameter when specifying object_audit_trail or
+            document_audit_trail as the {audit_trail_type}. Provide a
+            comma-separated list of one or more audit events to retrieve their
+            audit details. For example, events=Edit,Delete,TaskAssignment. If
+            omitted, defaults to all audit events. See Vault Help for full lists
+            of object audit events and document audit events.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: audit_trail_type
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/objects/documents/:{doc_id}/audittrail:
+    get:
+      tags:
+        - Logs > Audit History
+      summary: Retrieve Complete Audit History for a Single Document
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Document_Audit_History
+
+
+
+        Retrieve complete audit history for a single document.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: start_date
+          in: query
+          schema:
+            type: string
+          description: >
+            Specify a start date to retrieve audit history. This date cannot be
+            more than 30 days ago. Dates must be YYYY-MM-DDTHH:MM:SSZ format,
+            for example, 7AM on January 15, 2018 would use 2018-01-15T07:00:00Z.
+            If omitted, defaults to the vault’s creation date.
+        - name: end_date
+          in: query
+          schema:
+            type: string
+          description: >
+            Specify an end date to retrieve audit history. This date cannot be
+            more than 30 days ago. Dates must be YYYY-MM-DDTHH:MM:SSZ format,
+            for example, 7AM on January 15, 2018 would use 2018-01-15T07:00:00Z.
+            If omitted, defaults to today’s date.
+        - name: format_result
+          in: query
+          schema:
+            type: string
+          description: |
+            To request a CSV file of your audit history, use csv.
+        - name: limit
+          in: query
+          schema:
+            type: string
+          description: >-
+            Paginate the results by specifying the maximum number of histories
+            per page in the response. This can be any value between 1 and 1000.
+            If omitted, defaults to 200.
+        - name: offset
+          in: query
+          schema:
+            type: string
+          description: >-
+            Paginate the results displayed per page by specifying the amount of
+            offset from the entry returned. For example, if you are viewing the
+            first 50 results (page 1) and want to see the next page, set this to
+            offset=51. If omitted, defaults to 0.
+        - name: events
+          in: query
+          schema:
+            type: string
+          description: >-
+            Provide a comma-separated list of one or more audit events to
+            retrieve their audit history. See Vault Help for a full list of
+            document audit events. The values passed to this parameter are case
+            sensitive. For example, events=WorkflowCompletion,TaskAssignment. If
+            omitted, defaults to all audit events.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: doc_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/vobjects/:{object_name}/:{object_record_id}/audittrail:
+    get:
+      tags:
+        - Logs > Audit History
+      summary: Retrieve Complete Audit History for a Single Object Record
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Object_Audit_History
+
+
+
+        Retrieve complete audit history for a single object record.
+
+
+        Vault does not audit individual field values for newly created records.
+        For example, the audit trail for a new *Product* record would only
+        include a single entry, and the *Event Description* would be “Product:
+        CholeCap created”. We recommend <a
+        href="https://developer.veevavault.com/api/24.3#Retrieve_Object_Record">exporting
+        the current record</a> along with the audit trail to ensure a complete
+        export of all values. When a user deletes an object record, the audit
+        trail captures all field values.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: start_date
+          in: query
+          schema:
+            type: string
+          description: >
+            Specify a start date to retrieve audit history. This date cannot be
+            more than 30 days ago. Dates must be YYYY-MM-DDTHH:MM:SSZ format,
+            for example, 7AM on January 15, 2018 would use 2018-01-15T07:00:00Z.
+            If omitted, defaults to the vVault’s creation date.
+        - name: end_date
+          in: query
+          schema:
+            type: string
+          description: >
+            Specify an end date to retrieve audit history. This date cannot be
+            more than 30 days ago. Dates must be YYYY-MM-DDTHH:MM:SSZ format,
+            for example, 7AM on January 15, 2018 would use 2018-01-15T07:00:00Z.
+            If omitted, defaults to today’s date.
+        - name: format_result
+          in: query
+          schema:
+            type: string
+          description: |
+            To request a CSV file of your audit history, use csv.
+        - name: limit
+          in: query
+          schema:
+            type: string
+          description: >-
+            Paginate the results by specifying the maximum number of histories
+            per page in the response. This can be any value between 1 and 1000.
+            If omitted, defaults to 200.
+        - name: offset
+          in: query
+          schema:
+            type: string
+          description: >-
+            Paginate the results displayed per page by specifying the amount of
+            offset from the entry returned. For example, if you are viewing the
+            first 50 results (page 1) and want to see the next page, set this to
+            offset=51. If omitted, defaults to 0.
+        - name: events
+          in: query
+          schema:
+            type: string
+          description: >-
+            Provide a comma-separated list of one or more audit events to
+            retrieve their audit history. See Vault Help for a full list of
+            object audit events. The values passed to this parameter are case
+            sensitive. For example, events=Copy,Edit,Delete. If omitted,
+            defaults to all audit events.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: object_record_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/logs/code/debug:
+    get:
+      tags:
+        - Logs > SDK Debug Log
+      summary: Retrieve All Debug Logs
+      description: "[https://developer.veevavault.com/api/25.1/#Retrieve_All_Debug_Logs](https://developer.veevavault.com/api/25.1/#Retrieve_All_Debug_Logs)\n\nRetrieve all\_[debug log](https://developer.veevavault.com/sdk/#Debug_Log)\_sessions in the authenticated Vault.\n\n#### Example Response\n\n``` json\n{\n    \"responseStatus\": \"SUCCESS\",\n    \"data\": [\n        {\n            \"id\": \"0LS000000003006\",\n            \"name\": \"Record Trigger Troubleshooting\",\n            \"user_id\": 61603,\n            \"log_level\": \"all__sys\",\n            \"expiration_date\": \"2025-01-11T03:09:47.000Z\",\n            \"class_filters\": [\n                {\n                    \"name\": \"com.veeva.vault.custom.triggers.HelloWorld\",\n                    \"code_type\": \"Recordtrigger\"\n                }\n            ],\n            \"status\": \"active__sys\",\n            \"created_date\": \"2024-12-12T03:09:47.000Z\"\n        }\n    ]\n}\n\n ```\n\n#### Response Details\n\nOn `SUCCESS`, the response includes the following `data` for each debug log:\n\n| Name | Description |\n| --- | --- |\n| `id` | The numerical ID of this debug log. |\n| `name` | The UI name of this debug log. |\n| `user_id` | The ID of the user associated with this debug log. |\n| `log_level` | The level of error messages captured in this debug log.  <br>Learn more about the [log level types in Vault Help](https://platform.veevavault.help/en/lr/14341/#debug-log). |\n| `expiration_date` | The date this session will expire, in the format `YYYY-MM-DDTHH:MM:SS.000Z`. Once expired, Vault deletes the debug log and all log data. |\n| `class_filters` | Class filters applied to this debug log, if any. Class filters allow you to restrict debug log entries to only include entries for specific classes. |\n| `status` | The status of this debug log, either active or inactive. By default, only active logs are included in the response. To include inactive logs, set the `include_inactive` query parameter to `true`. |\n| `created_date` | The date this session was created, in the format `YYYY-MM-DDTHH:MM:SS.000Z`. |"
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: user_id
+          in: query
+          schema:
+            type: string
+          description: >-
+            Filter results to retrieve the debug log for this user ID only. If
+            omitted, this request retrieves debug logs for all users in the
+            Vault.
+        - name: include_inactive
+          in: query
+          schema:
+            type: boolean
+          description: >-
+            Set to `true` to include debug log sessions with a status of
+            `inactive__sys` in the response. If omitted, defaults to `false` and
+            inactive sessions are not included in the response.
+          example: 'true'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Logs > SDK Debug Log
+      summary: Create Debug Log
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Create_Debug_Log](https://developer.veevavault.com/api/25.1/#Create_Debug_Log)
+
+
+        Create a new [debug
+        log](https://developer.veevavault.com/sdk/#Debug_Log) session for a
+        user.
+
+
+        Debug logs have the following limits:
+
+
+        - Maximum one (1) debug log per user
+            
+        - Maximum 20 debug logs per Vault
+            
+
+        #### Example Response
+
+
+        ``` json
+
+        {
+            "responseStatus": "SUCCESS",
+            "data": {
+                "id": "0LS000000003001"
+            }
+        }
+
+         ```
+
+        #### Response Details
+
+
+        On `SUCCESS`, Vault returns the `id` of the new debug log.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: multipart/form-data
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: ''
+          in: query
+          schema:
+            type: string
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/logs/code/debug/:{id}:
+    get:
+      tags:
+        - Logs > SDK Debug Log
+      summary: Retrieve Single Debug Log
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Retrieve_Single_Debug_Log](https://developer.veevavault.com/api/25.1/#Retrieve_Single_Debug_Log)
+
+
+        Given a [debug log](https://developer.veevavault.com/sdk/#Debug_Log) ID,
+        retrieve details about this debug log.
+
+
+        #### Example Response
+
+
+        ``` json
+
+        {
+            "responseStatus": "SUCCESS",
+            "data": {
+                "id": "0LS000000003006",
+                "name": "Record Trigger Troubleshooting",
+                "user_id": 61603,
+                "log_level": "all__sys",
+                "expiration_date": "2025-01-11T03:09:47.000Z",
+                "class_filters": [
+                    {
+                        "name": "com.veeva.vault.custom.HelloWorld",
+                        "code_type": "Pagecontroller"
+                    },
+                    {
+                        "name": "com.veeva.vault.custom.triggers.HelloWorld",
+                        "code_type": "Recordtrigger"
+                    }
+                ],
+                "status": "active__sys",
+                "created_date": "2024-12-12T03:09:47.000Z"
+            }
+        }
+
+         ```
+
+        #### Response Details
+
+
+        On `SUCCESS`, the response includes the following `data` for this debug
+        log:
+
+
+        | Name | Description |
+
+        | --- | --- |
+
+        | `id` | The numerical ID of this debug log. |
+
+        | `name` | The UI name of this debug log. |
+
+        | `user_id` | The ID of the user associated with this debug log. |
+
+        | `log_level` | The level of error messages captured in this debug log. 
+        <br>Learn more about the [log level types in Vault
+        Help](https://platform.veevavault.help/en/lr/14341/#debug-log). |
+
+        | `expiration_date` | The date this session will expire, in the format
+        `YYYY-MM-DDTHH:MM:SS.000Z`. Once expired, Vault deletes the debug log
+        and all log data. |
+
+        | `class_filters` | Class filters applied to this debug log, if any.
+        Class filters allow you to restrict debug log entries to only include
+        entries for specific classes. |
+
+        | `status` | The status of this debug log, either active or inactive. By
+        default, only active logs are included in the response. To include
+        inactive logs, set the `include_inactive` query parameter to `true`. |
+
+        | `created_date` | The date this session was created, in the format
+        `YYYY-MM-DDTHH:MM:SS.000Z`. |
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: ''
+          in: query
+          schema:
+            type: string
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/logs/code/debug/:{id}/files:
+    get:
+      tags:
+        - Logs > SDK Debug Log
+      summary: Download Debug Log Files
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Download_Debug_Log_Files](https://developer.veevavault.com/api/25.1/#Download_Debug_Log_Files)
+
+
+        Given a [debug log](https://developer.veevavault.com/sdk/#Debug_Log) ID,
+        download all of this debug log’s files.
+
+
+        #### Example Response Headers
+
+
+        ``` bash
+
+        Content-Type: application/zip;charset=UTF-8
+
+        Content-Disposition:
+        attachment;filename="vaultjavasdk_61603_debuglogs_12-18-2024.zip"
+
+         ```
+
+        #### Response Details
+
+
+        On `SUCCESS`, Vault begins a download of the files for the specified
+        debug log. The files are packaged in a ZIP file with the file name:
+        `vaultjavasdk_{user_id}_debuglogs_{MM-DD-YYYY}.zip`.
+
+
+        The HTTP Response Header `Content-Type` is set to
+        `application/zip;charset=UTF-8`. The HTTP Response Header
+        `Content-Disposition` contains a filename component which can be used
+        when naming the local file.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: ''
+          in: query
+          schema:
+            type: string
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/logs/code/debug/:{id}/actions/reset:
+    post:
+      tags:
+        - Logs > SDK Debug Log
+      summary: Reset Debug Log
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Reset_Debug_Log](https://developer.veevavault.com/api/25.1/#Reset_Debug_Log)
+
+
+        Given a [debug log](https://developer.veevavault.com/sdk/#Debug_Log) ID,
+        delete all existing log files and reset the expiration date to 30 days
+        from today.
+
+
+        #### Example Response
+
+
+        ``` json
+
+        {
+           "responseStatus": "SUCCESS"
+        }
+
+         ```
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: ''
+          in: query
+          schema:
+            type: string
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Logs > SDK Debug Log
+      summary: Delete Debug Log
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Delete_Debug_Log](https://developer.veevavault.com/api/25.1/#Delete_Debug_Log)
+
+
+        Given a [debug log](https://developer.veevavault.com/sdk/#Debug_Log) ID,
+        delete this debug log and all log files.
+
+
+        #### Example Response
+
+
+        ``` json
+
+        {
+           "responseStatus": "SUCCESS"
+        }
+
+         ```
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: ''
+          in: query
+          schema:
+            type: string
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/code/profiler:
+    get:
+      tags:
+        - Logs > SDK Request Profiler
+      summary: Retrieve All Profiling Sessions
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Retrieve_All_Profiling_Sessions](https://developer.veevavault.com/api/25.1/#Retrieve_All_Profiling_Sessions)
+
+
+        List all SDK request profiling sessions in the currently authenticated
+        Vault.
+
+
+        #### Example Response
+
+
+        ``` json
+
+        {
+           "responseStatus": "SUCCESS",
+           "data": [
+               {
+                   "id": "0LS000000003002",
+                   "label": "Baseline",
+                   "name": "baseline__c",
+                   "description": null,
+                   "status": "processing__sys",
+                   "user_id": null,
+                   "created_date": "2024-08-23T23:22:00.000Z",
+                   "expiration_date": "2024-09-22T23:22:00.000Z"
+               },
+               {
+                   "id": "0LS000000002001",
+                   "label": "Hotfix Dry Run 02",
+                   "name": "hotfix_dry_run_02__c",
+                   "description": null,
+                   "status": "complete__sys",
+                   "user_id": 123456789,
+                   "created_date": "2024-08-20T02:21:21.000Z",
+                   "expiration_date": "2024-09-19T02:31:47.000Z"
+               },
+               {
+                   "id": "0LS000000001001",
+                   "label": "Hotfix Dry Run 01",
+                   "name": "hotfix_dry_run_01__c",
+                   "description": null,
+                   "status": "complete__sys",
+                   "user_id": null,
+                   "created_date": "2024-08-20T01:42:02.000Z",
+                   "expiration_date": "2024-09-19T02:11:25.000Z"
+               }
+           ]
+        }
+
+         ```
+
+        #### Response Details
+
+
+        On `SUCCESS`, the response includes the following `data` for each
+        profiling session:
+
+
+        | Name | Description |
+
+        | --- | --- |
+
+        | `id` | The numerical ID of this profiling session. |
+
+        | `label` | The UI label of this profiling session. For example,
+        "Baseline". |
+
+        | `name` | The API name of this profiling session. For example,
+        `baseline__c`. You can use this value to [end the profiling session
+        early](https://developer.veevavault.com/api/25.1/#End_Profiling_Session),
+        [download the
+        results](https://developer.veevavault.com/api/25.1/#Download_Profiling_Session_Results),
+        or [delete the
+        session](https://developer.veevavault.com/api/25.1/#Delete_Profiling_Session).
+        |
+
+        | `description` | The description of this profiling session. |
+
+        | `status` | The status of this session, either:  <br>  <br>\-
+        `in_progress__sys`: The session is actively running and collecting SDK
+        request data.  <br>  <br>\- `processing__sys`: The session is no longer
+        running, but the session is still active as Vault processes the data.
+        The results are not yet available for download.  <br>  <br>\-
+        `complete__sys`: The session is over, and the results are available for
+        download. This session is inactive. |
+
+        | `user_id` | The ID of the user associated with this session. If
+        `null`, this session applies to all users. |
+
+        | `created_date` | The date this session was created, in the format
+        `YYYY-MM-DDTHH:MM:SS.000Z`. |
+
+        | `expiration_date` | The date this session will expire, in the format
+        `YYYY-MM-DDTHH:MM:SS.000Z`. Once expired, Vault deletes the session and
+        all session data. |
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Logs > SDK Request Profiler
+      summary: Create Profiling Session
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Create_Profiling_Session](https://developer.veevavault.com/api/25.1/#Create_Profiling_Session)
+
+
+        Create a new SDK request profiling session. Profiling sessions allow
+        developers to troubleshoot custom code and improve code quality by
+        analyzing results at the SDK request level.
+
+
+        Vault starts the profiling session immediately on creation. Profiling
+        sessions run for either 20 minutes or up to 10,000 SDK requests,
+        whichever comes first. To end a session early, use the [End Profiling
+        Session](https://developer.veevavault.com/api/25.1/#End_Profiling_Session)
+        endpoint. Once ended, a session’s `status` is `processing__sys` while
+        Vault prepares the data, which may take about 15 minutes. Once the
+        `status` is `complete__sys`, the data is available for download with the
+        [Download Profiling Session
+        Results](https://developer.veevavault.com/api/25.1/#Download_Profiling_Session_Results)
+        endpoint.
+
+
+        Only one profiling session can be active at a time. Because sessions
+        begin immediately on creation, you cannot create a new session until the
+        current session becomes inactive. Additionally, each Vault can only
+        retain profiling session data for up to 10 sessions. If your Vault
+        already has 10 profiling sessions, you must [Delete a Profiling
+        Session](https://developer.veevavault.com/api/25.1/#Delete_Profiling_Session)
+        before creating a new one.
+
+
+        #### Example Response
+
+
+        ``` json
+
+        {
+           "responseStatus": "SUCCESS",
+           "data": {
+               "id": "0LS000000003003",
+               "name": "hotfix_dry_run_01__c"
+           }
+        }
+
+         ```
+
+        #### Response Details
+
+
+        On `SUCCESS`, Vault starts the profiling session immediately and returns
+        the session `id` and `name`.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/x-www-form-urlencoded
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/code/profiler/:{session_name}:
+    get:
+      tags:
+        - Logs > SDK Request Profiler
+      summary: Retrieve Profiling Session
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Retrieve_Profiling_Session](https://developer.veevavault.com/api/25.1/#Retrieve_Profiling_Session)
+
+
+        Retrieve details about a specific SDK request profiling session.
+
+
+        #### Example Response
+
+
+        ``` json
+
+        {
+           "responseStatus": "SUCCESS",
+           "data": {
+               "id": "0LS000000003002",
+               "label": "Baseline",
+               "name": "baseline__c",
+               "description": null,
+               "status": "complete__sys",
+               "user_id": null,
+               "created_date": "2024-08-23T23:22:00.000Z",
+               "expiration_date": "2024-09-22T23:36:21.000Z"
+           }
+        }
+
+         ```
+
+        #### Response Details
+
+
+        On `SUCCESS`, the response includes the following `data` for each
+        profiling session:
+
+
+        | Name | Description |
+
+        | --- | --- |
+
+        | `id` | The numerical ID of this profiling session. |
+
+        | `label` | The UI label of this profiling session. For example,
+        "Baseline". |
+
+        | `name` | The API name of this profiling session. For example,
+        `baseline__c`. You can use this value to [end the profiling session
+        early](https://developer.veevavault.com/api/25.1/#End_Profiling_Session),
+        [download the
+        results](https://developer.veevavault.com/api/25.1/#Download_Profiling_Session_Results),
+        or [delete the
+        session](https://developer.veevavault.com/api/25.1/#Delete_Profiling_Session).
+        |
+
+        | `description` | The description of this profiling session. |
+
+        | `status` | The status of this session, either:  <br>  <br>\-
+        `in_progress__sys`: The session is actively running and collecting SDK
+        request data.  <br>  <br>\- `processing__sys`: The session is no longer
+        running, but the session is still active as Vault processes the data.
+        The results are not yet available for download.  <br>  <br>\-
+        `complete__sys`: The session is over, and the results are available for
+        download. This session is inactive. |
+
+        | `user_id` | The ID of the user associated with this session. If
+        `null`, this session applies to all users. |
+
+        | `created_date` | The date this session was created, in the format
+        `YYYY-MM-DDTHH:MM:SS.000Z`. |
+
+        | `expiration_date` | The date this session will expire, in the format
+        `YYYY-MM-DDTHH:MM:SS.000Z`. Once expired, Vault deletes the session and
+        all session data. |
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: session_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Logs > SDK Request Profiler
+      summary: Delete Profiling Session
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Delete_Profiling_Session](https://developer.veevavault.com/api/25.1/#Delete_Profiling_Session)
+
+
+        Delete an inactive profiling session, which deletes the session and all
+        data associated with the session. Inactive sessions have a `status` of
+        `complete__sys`.
+
+
+        #### Example Response
+
+
+        ``` json
+
+        {
+           "responseStatus": "SUCCESS"
+        }
+
+         ```
+
+        #### Response Details
+
+
+        On `SUCCESS`, the Vault deletes the specified profiling session and
+        deletes all data associated with the session.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: session_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/code/profiler/:{session_name}/actions/end:
+    post:
+      tags:
+        - Logs > SDK Request Profiler
+      summary: End Profiling Session
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#End_Profiling_Session](https://developer.veevavault.com/api/25.1/#End_Profiling_Session)
+
+
+        Terminate a profiling session early. By default, profiling sessions run
+        for either 20 minutes or up to 10,000 SDK requests, whichever comes
+        first.
+
+
+        Once ended, a session’s `status` is `processing__sys` while Vault
+        prepares the data, which may take about 15 minutes. Once the `status` is
+        `complete__sys`, the data is available for download with the [Download
+        Profiling Session
+        Results](https://developer.veevavault.com/api/25.1/#Download_Profiling_Session_Results)
+        endpoint.
+
+
+        #### Example Response
+
+
+        ``` json
+
+        {
+           "responseStatus": "SUCCESS"
+        }
+         ```
+
+        #### Response Details
+
+
+        On `SUCCESS`, the Vault ends the profiling session. The session’s
+        `status` becomes `processing__sys` while Vault prepares the data, which
+        may take about 15 minutes. 
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: session_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/code/profiler/:{session_name}/results:
+    get:
+      tags:
+        - Logs > SDK Request Profiler
+      summary: Download Profiling Session Results
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Delete_Profiling_Session](https://developer.veevavault.com/api/25.1/#Delete_Profiling_Session)
+
+
+        Download the Profiler Log for a specific profiling session. A profiling
+        session log is a CSV which contains one row for each SDK request, with a
+        maximum of 100,000 rows.
+
+
+        #### Example Response Headers
+
+
+        ``` bash
+
+        Content-Type: application/zip;charset=UTF-8
+
+        Content-Disposition: attachment;filename="baseline__c.zip"
+
+         ```
+
+        #### Response Details
+
+
+        On `SUCCESS`, Vault downloads the results of the specified profiling
+        session. The HTTP Response Header `Content-Type` is set to
+        `application/zip`. The HTTP Response Header `Content-Disposition`
+        contains a filename component which can be used when naming the local
+        file.
+
+
+        The log is a CSV file with the following information for each SDK
+        request:
+
+
+        | Name | Description |
+
+        | --- | --- |
+
+        | `timestamp` | The time this SDK request began executing. |
+
+        | `user_id` | The ID of the user who initiated this request. |
+
+        | `user_name` | The user name of the user who initiated this request. |
+
+        | `execution_id` | This SDK request’s execution ID. |
+
+        | `sdk_request_id` | The ID of this SDK request. |
+
+        | `sdk_count` | The number of SDK entry points evoked during this
+        request. |
+
+        | `sdk_cpu_time` | The CPU time, in nanoseconds. |
+
+        | `sdk_elapsed_time` | The total elapsed time, in milliseconds. |
+
+        | `sdk_gross_memory` | The memory consumed, in bytes. |
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: session_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/notifications/histories:
+    get:
+      tags:
+        - Logs
+      summary: Retrieve Email Notification Histories
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Email_Notification_History
+
+
+
+        Retrieve details about the email notifications sent by Vault. Details
+        include the notification date, recipient, subject, and delivery status.
+        In the UI, this information is available in **Admin > Operations > Email
+        Notification Status**. Learn more about <a
+        href="https://platform.veevavault.help/en/lr/514128">Email Notification
+        Status in Vault Help</a>.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: start_date
+          in: query
+          schema:
+            type: string
+          description: >-
+            Specify a start date to retrieve notification history. This date
+            cannot be more than 2 years ago. Dates must be in YYYY-MM-DD or
+            YYYY-MM-DDTHH:mm:ssZ format. If time is omitted (THH:mm:ssZ),
+            defaults to the start of the day. If start_date is omitted entirely,
+            defaults to the start of the previous day.
+
+            If you’ve specified a start_date, you must also specify an end_date.
+          example: YYYY-MM-DD
+        - name: end_date
+          in: query
+          schema:
+            type: string
+          description: >-
+            Specify an end date to retrieve notification history. This date
+            cannot be more than 30 days away from the specified start_date.
+            Dates must be in YYYY-MM-DD or YYYY-MM-DDTHH:mm:ssZ format. If time
+            is omitted (THH:mm:ssZ), defaults to the time of the API request.
+
+            If you’ve specified an end_date, you must also specify a start_date.
+          example: YYYY-MM-DD
+        - name: all_dates
+          in: query
+          schema:
+            type: boolean
+          description: >-
+            Set to true to request notification history for all dates. This is
+            the same as requesting a full CSV export from the Vault UI. When
+            requesting a full notification history, you must leave start_date
+            and end_date blank and set format_result to csv. You can request an
+            export of notification history for all_dates once every 24 hours.
+          example: 'true'
+        - name: format_result
+          in: query
+          schema:
+            type: string
+          description: >-
+            To request a downloadable CSV file of your notification history, set
+            this parameter to csv. The response contains a jobId to retrieve the
+            job status, which provides a link to download the CSV file. If
+            omitted, the API returns a JSON response with notification history
+            and does not start a job. If all_dates is true, this parameter must
+            be csv.
+          example: csv
+        - name: limit
+          in: query
+          schema:
+            type: string
+          description: >-
+            Paginate the results by specifying the maximum number of histories
+            per page in the response. This can be any value between 1 and 1000.
+            If omitted, defaults to 200.
+        - name: offset
+          in: query
+          schema:
+            type: string
+          description: >-
+            Paginate the results displayed per page by specifying the amount of
+            offset from the entry returned. If omitted, defaults to 0.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/logs/api_usage:
+    get:
+      tags:
+        - Logs
+      summary: Download Daily API Usage
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#API_Usage](https://developer.veevavault.com/api/25.1/#API_Usage)
+
+
+        Retrieve the **API Usage Log** for a single day, up to 30 days in the
+        past. The log contains information such as user name, user ID, remaining
+        burst limit, and the endpoint called. Users with the _Admin: Logs: API
+        Usage Logs_ permission can access these logs.
+
+
+        Note that the daily logs may have a delay of about 15 minutes. If your
+        log does not include appropriate data, know that your data is not lost;
+        it is just not yet populated.
+
+
+        The logs are designed for troubleshooting burst limits and discovering
+        which of your integrations are causing you to hit the limit. These logs
+        should not be used for auditing, as they are not designed with the
+        appropriate level of restrictions. For example, if an API request fails
+        to enter the usage log, the API call is not prevented from executing,
+        which would be required if this log was designed for auditing. In rare
+        cases an API call may not show up as an entry in the log, but know that
+        all calls are accurately reflected in your burst limit counts.
+
+
+        #### Headers
+
+
+        Note that this `Accept` header only changes the format of the response
+        in the case of an error. This does not change the file format of the
+        download.
+
+
+        | Name | Description |
+
+        | --- | --- |
+
+        | `Accept` | `application/json` (default) or `application/xml` |
+
+
+        #### Example Response Headers
+
+
+        ``` bash
+
+        Content-Type: application/octet-stream;charset=UTF-8
+
+        Content-Disposition: attachment;filename="response.zip"
+
+         ```
+
+        #### Response Details
+
+
+        On `SUCCESS`, Vault retrieves the log from the specified date as a .ZIP
+        file. The HTTP Response Header `Content-Type` is set to
+        `application/octet-stream`. The returned CSV or Logfile includes the
+        following data:
+
+
+        | Name | Description |
+
+        | --- | --- |
+
+        | `timestamp` | The date and time of this API request, in UTC. |
+
+        | `session_id` | The Session ID of the user who made the request. |
+
+        | `user_id` | The ID of the user who made the request. |
+
+        | `username` | The Vault user name (login credentials) of the user who
+        made the request. |
+
+        | `http_method` | The HTTP Method of the request, for example, `POST`. |
+
+        | `endpoint` | The Vault API endpoint used for this request. |
+
+        | `http_response_status` | The HTTP response status of the request, for
+        example, 200. |
+
+        | `api_version` | The Vault API version used for this request, for
+        example, v18.1. This value is blank for endpoints which do not have an
+        API version. |
+
+        | `api_response_status` | The API response status, for example,
+        `SUCCESS`. This column may be blank for requests where the response
+        contains binary content, such as files. |
+
+        | `api_response_error_type` | The API response error type, for example,
+        `INSUFFICIENT_ACCESS`. |
+
+        | `execution_id` | Unique ID generated by Vault for each API request.
+        Returned in the response header `X-VaultAPI-ExecutionId`. |
+
+        | `client_id` | The client ID passed with this request. If the API
+        request did not include a client ID, this value is `unknown`. If the API
+        received a `client_id` which was incorrectly formatted, this value is
+        `invalid_client_id`. Learn more about [Client ID in the Vault API
+        Documentation](https://developer.veevavault.com/docs/#Client_ID). |
+
+        | `client_ip` | The IP address of the client, which is where the call
+        originated. |
+
+        | `burst_limit_remaining` | The number of API calls remaining in your
+        burst limit. Learn more about [API
+        Limits](https://developer.veevavault.com/docs/#api_rate_limits). |
+
+        | `duration` | The time it takes an API request to execute in Vault,
+        measured in milliseconds. Note the duration does not include transport
+        times between Vault and the client. |
+
+        | `response_delay` | This column is populated whenever API calls are
+        throttled and indicates the length of the delay in milliseconds. |
+
+        | `sdk_count` | This column is populated if the API request invoked
+        custom Vault Java SDK code, and indicates the total number of SDK entry
+        points executed in this request. Learn more about [Vault Java SDK
+        performance
+        metrics](https://developer.veevavault.com/docs/#SDK_Performance_API_Headers).
+        |
+
+        | `sdk_cpu_time` | This column is populated if the API request invoked
+        custom Vault Java SDK code, and indicates the total CPU processing time
+        required for this request in nanoseconds. Learn more about [Vault Java
+        SDK performance
+        metrics](https://developer.veevavault.com/docs/#SDK_Performance_API_Headers).
+        |
+
+        | `sdk_elasped_time` | This column is populated if the API request
+        invoked custom Vault Java SDK code, and indicates the total elapsed time
+        for this request in milliseconds. Learn more about [Vault Java SDK
+        performance
+        metrics](https://developer.veevavault.com/docs/#SDK_Performance_API_Headers).
+        |
+
+        | `sdk_gross_memory` | This column is populated if the API request
+        invoked custom Vault Java SDK code, and indicates the total gross memory
+        required for this request in bytes. Learn more about [Vault Java SDK
+        performance
+        metrics](https://developer.veevavault.com/docs/#SDK_Performance_API_Headers).
+        |
+
+        | `connection` | The `api_name__sys` of the matching _Connection_ record
+        associated with this request. If this is a trusted Veeva connection,
+        such as Vault Loader, Vault Mobile, or Station Manager, this value is
+        `vault__sys`. If there is no associated connection, this value is blank.
+        |
+
+        | `api_resource` | The API resource for the request. For example, the
+        primary query object for a VQL request. |
+
+        | `api_response_warning_type` | The API request warning type. For
+        example, `DUPLICATE`. |
+
+        | `api_response_warning_message` | The API request warning message. For
+        example, “Duplicate query execution detected. Consider caching commonly
+        required data.” |
+
+        | `api_response_error_message` | The API request error message. For
+        example, “product__b is not a queryable object; please refer to api
+        documentation”. |
+
+        | `reference_id` | The `X-VaultAPI-ReferenceId`header value. If this
+        header was not included in the request, this value is blank. |
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: date
+          in: query
+          schema:
+            type: string
+          description: >-
+            The day to retrieve the API Usage log. Date is in UTC and follows
+            the format YYYY-MM-DD. Date cannot be more than 30 days in the past.
+        - name: log_format
+          in: query
+          schema:
+            type: string
+          description: >
+            Optional: Specify the format to download. Possible values are csv or
+            logfile. If omitted, defaults to csv. Note that this call always
+            downloads a ZIP file. This parameter only changes the format of the
+            file contained within the ZIP.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/logs/code/runtime:
+    get:
+      tags:
+        - Logs
+      summary: Download SDK Runtime Log
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Download_Runtime_Log
+
+
+
+        Retrieve the *Runtime Log* for a single day, up to 30 days in the past.
+        Users with the *Admin: Logs: Vault Java SDK Logs* permission can access
+        these logs.
+
+
+        The runtime logs create entries 15 minutes after the Vault Java SDK
+        transaction completes. If you’ve recently encountered an error which is
+        not captured in the runtime log, wait for the transaction to finish and
+        check again. If your log does not include appropriate data, know that
+        your data is not lost; it is just not yet populated.
+
+
+        Learn more about the <a
+        href="https://developer.veevavault.com/sdk/#Runtime_Log">Vault Java SDK
+        runtime log</a>.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: date
+          in: query
+          schema:
+            type: string
+          example: YYYY-MM-DD
+        - name: log_format
+          in: query
+          schema:
+            type: string
+          description: >
+            Optional: Specify the format to download. Possible values are csv or
+            logfile. If omitted, defaults to csv. Note that this call always
+            downloads a ZIP file. This parameter only changes the format of the
+            file contained within the ZIP.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/file_staging/upload:
+    post:
+      tags:
+        - File Staging > Resumable Upload Sessions
+      summary: Create Resumable Upload Session
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Create_Upload_Session
+
+
+        Initiate a multipart upload session and return an upload session ID.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/file_staging/upload/:upload_session_id:
+    put:
+      tags:
+        - File Staging > Resumable Upload Sessions
+      summary: Upload to a Session
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Upload_to_Session
+
+
+
+        The session owner can upload parts of a file to an active upload
+        session. By default, you can upload up to 2000 parts per upload session,
+        and each part can be up to 50MB.  Use the `Range` header to specify the
+        range of bytes for each upload, or split files into parts and add each
+        part as a separate file. Each part must be the same size, except for the
+        last part in the upload session.
+
+      requestBody:
+        content:
+          text/plain: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/octet-stream
+        - name: X-VaultAPI-FilePartNumber
+          in: header
+          schema:
+            type: string
+          description: >-
+            The part number, which uniquely identifies a file part and defines
+            its position within the file as a whole. If a part is uploaded using
+            a part number that has already been used, Vault overwrites the
+            previously uploaded file part. You must upload parts in numerical
+            order. For example, you cannot upload part 3 without first uploading
+            parts 1 and 2.
+        - name: Content-MD5
+          in: header
+          schema:
+            type: string
+          description: 'Optional: The MD5 checksum of the file part being uploaded.'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - File Staging > Resumable Upload Sessions
+      summary: Commit Upload Session
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Commit_Upload_Session
+
+
+
+        Mark an upload session as complete and assemble all previously uploaded
+        parts to create a file.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    get:
+      tags:
+        - File Staging > Resumable Upload Sessions
+      summary: Get Upload Session Details
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Get_Upload_Session_Details
+
+
+
+        Retrieve the details of an active upload session. Admin users can get
+        details for all sessions, while non-Admin users can only get details for
+        sessions if they are the owner.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - File Staging > Resumable Upload Sessions
+      summary: Abort Upload Session
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Abort_Upload_Session
+
+
+
+        Abort an active upload session and purge all uploaded file parts. Admin
+        users can see and abort all upload sessions, while non-Admin users can
+        only see and abort sessions where they are the owner.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/file_staging/upload/:
+    get:
+      tags:
+        - File Staging > Resumable Upload Sessions
+      summary: List Upload Sessions
+      description: |+
+        https://developer.veevavault.com/api/25.1/#List_Upload_Sessions
+
+
+        Return a list of active upload sessions.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/file_staging/upload/:upload_session_id/parts:
+    get:
+      tags:
+        - File Staging > Resumable Upload Sessions
+      summary: List File Parts Uploaded to Session
+      description: >+
+        https://developer.veevavault.com/api/25.1/#List_File_Parts_Uploaded_to_Session
+
+
+
+        Return a list of parts uploaded in a session. You must be an Admin user
+        or the session owner.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: limit
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: The maximum number of items per page in the response. This
+            can be any value between 1 and 1000. If omitted, the default value
+            is 1000.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/file_staging/items/:item:
+    get:
+      tags:
+        - File Staging
+      summary: List Items at a Path
+      description: >-
+        https://developer.veevavault.com/api/25.1/#List_Items_at_a_Path
+
+
+        Return a list of files and folders for the specified path. Paths are
+        different for Admin users (Vault Owners and System Admins) and non-Admin
+        users. Learn more about <a
+        href="https://developer.veevavault.com/docs/#File_Staging_Path">paths in
+        the REST API Documentation</a>.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: recursive
+          in: query
+          schema:
+            type: string
+          description: >-
+            If true, the response will contain the contents of all subfolders.
+            If not specified, the default value is false.
+        - name: limit
+          in: query
+          schema:
+            type: string
+          description: >-
+            Optional: The maximum number of items per page in the response. This
+            can be any value between 1 and 1000. If omitted, the default value
+            is 1000.
+        - name: format_result
+          in: query
+          schema:
+            type: string
+          description: >-
+            If set to csv, the response includes a job_id. Use the Job ID value
+            to retrieve the status and results of the request.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    put:
+      tags:
+        - File Staging
+      summary: Update Folder or File
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Update_File_or_Folder
+
+
+        Move or rename a folder or file on the file staging server. You can move
+        and rename an item in the same request.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - File Staging
+      summary: Delete File or Folder
+      description: |-
+        https://developer.veevavault.com/api/25.1/#Delete_File_or_Folder
+
+        Delete an individual file or folder from the file staging server.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: recursive
+          in: query
+          schema:
+            type: string
+          description: >-
+            Applicable to deleting folders only. If true, the request will
+            delete the contents of a folder and all subfolders. The default is
+            false.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/file_staging/items/content/:item:
+    get:
+      tags:
+        - File Staging
+      summary: Download Item Content
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Get_Item_Content
+
+
+        Retrieve the content of a specified file from the file staging server.
+        Use the `Range` header to create resumable downloads for large files, or
+        to continue downloading a file if your session is interrupted.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Range
+          in: header
+          schema:
+            type: string
+          description: >-
+            Optional: Specifies a partial range of bytes to include in the
+            upload. Maximum 50 MB. Must be in the format `bytes={min}-{max}`.
+            For example, `bytes=0-1000`.
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/file_staging/items:
+    post:
+      tags:
+        - File Staging
+      summary: Create Folder or File
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Create_File_or_Folder
+
+
+        Upload files or folders up to 50MB to the File Staging Server. To upload
+        files larger than 50MB, see <a
+        href="https://developer.veevavault.com/api/25.1/#Resumable_Upload_Sessions">Resumable
+        Upload Sessions</a>. You can only create one file or folder per request.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-MD5
+          in: header
+          schema:
+            type: string
+          description: 'Optional: The MD5 checksum of the file being uploaded.'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/loader/extract:
+    post:
+      tags:
+        - Vault Loader > Multi-File Extract
+      summary: Extract Data Files
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Extract_Data_Files
+
+
+
+        Create a Loader job to extract one or more data files. Learn more about
+        <a href="https://platform.veevavault.help/en/lr/31536">extracting data
+        files with Vault Loader in Vault Help</a>.
+
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                - object_type: documents__v
+                  extract_options: include_renditions__v
+                  fields:
+                    - id
+                    - name__v
+                    - type__v
+                  vql_criteria__v: site__v=123
+                - object_type: vobjects__v
+                  object: product__v
+                  fields:
+                    - id
+                    - name__v
+                    - object_type__v
+                  vql_criteria__v: site__v=123
+                - object_type: groups__v
+                  fields:
+                    - id
+                    - name__v
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/loader/:{job_id}/tasks/:{task_id}/results:
+    get:
+      tags:
+        - Vault Loader > Multi-File Extract
+      summary: Retrieve Loader Extract Results
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Extract_Results
+
+
+
+        After submitting a request to extract object types from your Vault, you
+        can query Vault to retrieve results of a specified job task.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: job_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: task_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/loader/:{job_id}/tasks/:{task_id}/results/renditions:
+    get:
+      tags:
+        - Vault Loader > Multi-File Extract
+      summary: Retrieve Loader Extract Renditions Results
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Rendition_Results
+
+
+
+        After submitting a request to extract object types from your Vault, you
+        can query Vault to retrieve results of a specified job task that
+        includes renditions requested with documents.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: job_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: task_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/loader/load:
+    post:
+      tags:
+        - Vault Loader > Multi-File Load
+      summary: Load Data Objects
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Request_File_Load
+
+
+        Create a loader job and load a set of data files.
+
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                - object_type: documents__v
+                  action: create
+                  file: documents.csv
+                  order: 1
+                - object_type: vobjects__v
+                  object: product__v
+                  action: upsert
+                  file: products.csv
+                  order: 2
+                  idparam: external_id__v
+                - object_type: vobjects__v
+                  object: annotation_keywords__sys
+                  action: create
+                  file: claims.csv
+                  order: 3
+                  recordmigrationmode: true
+                - object_type: groups__v
+                  action: update
+                  file: groups.csv
+                  order: 4
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/loader/:{job_id}/tasks/:{task_id}/successlog:
+    get:
+      tags:
+        - Vault Loader > Multi-File Load
+      summary: Retrieve Load Success Log Results
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Load_Results
+
+
+        Retrieve success logs of the loader results.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: job_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: task_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/loader/:{job_id}/tasks/:{task_id}/failurelog:
+    get:
+      tags:
+        - Vault Loader > Multi-File Load
+      summary: Retrieve Load Failure Log Results
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Load_Results
+
+
+        Retrieve failure logs of the loader results.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: job_id
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: task_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/messages/:{message_type}/language/:{lang}/actions/export:
+    post:
+      tags:
+        - Bulk Translation
+      summary: Export Bulk Translation File
+      description: "[https://developer.veevavault.com/api/25.1/#Export_Bulk_Translation](https://developer.veevavault.com/api/25.1/#Export_Bulk_Translation)\n\nExport a bulk translation file from your Vault. The exported bulk translation file is a CSV editable in any text editor or translation software. You can request one (1) message type in one (1) language per request. Learn more about the\_[translation file schema in Vault Help](https://platform.veevavault.help/en/lr/13309/#field-labels-and-system-messages-translation-file).\n\nThis request starts an asynchronous job that exports the translation file to your Vault’s file staging server. You can then download this file with the\_[Download Item Content](https://developer.veevavault.com/api/25.1/#Get_Item_Content)\_request.\n\nYou must have the\__Admin: Language: Read_\_permission to export a bulk translation file from Vault.\n\n#### Response Details\n\nOn `SUCCESS`, the response includes the `url` and `job_id` of the job. You can use this to [retrieve the status](https://developer.veevavault.com/api/25.1/#Retrieve_Job_Status) and results of the request.\n\nWhen the job is complete, the translation files are available on your Vault’s file staging server. Retrieving the job status of this completed job provides the `href` to [download the CSV](https://developer.veevavault.com/api/25.1/#Get_Item_Content) from the file staging server.\n\n> **Response** \n  \n\n``` json\n{\n    \"responseStatus\": \"SUCCESS\",\n    \"data\": {\n        \"jobId\": \"902101\",\n        \"url\": \"/api/v24.2/services/jobs/902101\"\n    }\n}\n\n ```\n\n> **Response: Retrieve Job Status** \n  \n\n``` json\n{\n   \"responseStatus\": \"SUCCESS\",\n   \"data\": {\n       \"id\": 902101,\n       \"status\": \"SUCCESS\",\n       \"links\": [\n           {\n               \"rel\": \"self\",\n               \"href\": \"/api/v24.2/services/jobs/902101\",\n               \"method\": \"GET\",\n               \"accept\": \"application/json\"\n           },\n           {\n               \"rel\": \"file\",\n               \"href\": \"/api/v24.2/services/file_staging/items/PromoMats_English_Field-Labels_5-29-24_15-34-10.csv\",\n               \"method\": \"GET\",\n               \"accept\": \"application/json\"\n           },\n           {\n               \"rel\": \"content\",\n               \"href\": \"/api/v24.2/services/file_staging/items/content/PromoMats_English_Field-Labels_5-29-24_15-34-10.csv\",\n               \"method\": \"GET\",\n               \"accept\": \"application/octet-stream;charset=UTF-8\"\n           }\n       ],\n       \"created_by\": 61603,\n       \"created_date\": \"2024-05-29T21:34:11.000Z\",\n       \"run_start_date\": \"2024-05-29T21:34:11.000Z\",\n       \"run_end_date\": \"2024-05-29T21:34:20.000Z\"\n   }\n}\n\n ```"
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: message_type
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: lang
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/messages/:{message_type}/actions/import:
+    post:
+      tags:
+        - Bulk Translation
+      summary: Import Bulk Translation File
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Import_Bulk_Translation](https://developer.veevavault.com/api/25.1/#Import_Bulk_Translation)
+
+
+        Import a bulk translation file into Vault. While an exported bulk
+        translation file can contain only one (1) language, your import file may
+        include multiple languages. Vault reads the language value separately
+        for each row and applies any new translations immediately. Vault ignores
+        any rows without changes. Learn more about the [translation file schema
+        in Vault
+        Help](https://platform.veevavault.help/en/lr/13309/#field-labels-and-system-messages-translation-file).
+
+
+        You must have the _Admin: Language: Edit_ permission to import a bulk
+        translation file to Vault.
+
+
+        Upload the CSV file to your Vault’s file staging server before making
+        this request.
+
+
+        - The maximum CSV input file size is 1GB.
+
+        - The values in the input must be UTF-8 encoded.
+
+        - CSVs must follow the standard RFC 4180 format, with some
+        [exceptions](https://developer.veevavault.com/docs/#CSV_RFC_Deviations).
+            
+
+        #### Response Details
+
+
+        On `SUCCESS`, the response includes the `job_id` which allows you to:
+
+
+        - [Retrieve the job
+        status](https://developer.veevavault.com/api/25.1/#Retrieve_Job_Status),
+        which specifies if the import job has completed with `SUCCESS`
+
+        - [Retrieve the job
+        summary](https://developer.veevavault.com/api/25.1/#Translation_Summary),
+        which provides details of a successful job
+
+        - [Retrieve the job
+        errors](https://developer.veevavault.com/api/25.1/#Translation_Errors),
+        which provides details about the errors encountered in the job (if any)
+            
+
+        > **Response** 
+          
+
+        ``` json
+
+        {
+            "responseStatus": "SUCCESS",
+            "data": {
+                "url": "/api/v24.2/services/jobs/902601",
+                "jobId": "902601"
+            }
+        }
+
+         ```
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: message_type
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/jobs/:{job_id}/summary:
+    get:
+      tags:
+        - Bulk Translation
+      summary: Retrieve Import Bulk Translation File Job Summary
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Translation_Summary](https://developer.veevavault.com/api/25.1/#Translation_Summary)
+
+
+        After submitting a request to import a bulk translation file, you can
+        query Vault to determine the results of the request.
+
+
+        Before submitting this request:
+
+
+        - You must have previously requested an [Import Bulk Translation
+        File](https://developer.veevavault.com/api/25.1/#Import_Bulk_Translation)
+        job (via the API) which is no longer active
+
+        - You must be the user who initiated the job or have the _Admin: Jobs:
+        Read_ permission
+            
+
+        #### Response Details
+
+
+        On `SUCCESS`, the response includes the following `data`:
+
+
+        - `ignored`: The number of rows that were ignored. For example, Vault
+        ignores any rows without changes.
+
+        - `updated`: The number of existing rows that were updated successfully.
+
+        - `failed`: The number of rows that attempted an update but failed. Use
+        the [Retrieve Import Bulk Translation File Job
+        Errors](https://developer.veevavault.com/api/25.1/#Translation_Errors)
+        endpoint to retrieve details about these rows.
+
+        - `added`: The number of new rows that were added.
+            
+
+        > Response 
+          
+
+        ``` json
+
+        {
+           "responseStatus": "SUCCESS",
+           "data": {
+               "ignored": 14057,
+               "updated": 14,
+               "failed": 179,
+               "added": 0
+           }
+        }
+
+         ```
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: job_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/jobs/:{job_id}/errors:
+    get:
+      tags:
+        - Bulk Translation
+      summary: Retrieve Import Bulk Translation File Job Errors
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Translation_Errors](https://developer.veevavault.com/api/25.1/#Translation_Errors)
+
+
+        After submitting a request to import a bulk translation file, you can
+        query Vault to determine the errors from the request (if any).
+
+
+        Before submitting this request:
+
+
+        - You must have previously requested an [Import Bulk Translation
+        File](https://developer.veevavault.com/api/25.1/#Import_Bulk_Translation)
+        job (via the API) which is no longer active
+
+        - You must be the user who initiated the job or have the _Admin: Jobs:
+        Read_ permission
+            
+
+        #### Response Details
+
+
+        On `SUCCESS`, the response includes the line number and error message
+        for any errors encountered in the job.
+
+
+        > Response 
+          
+
+        ```
+
+        "Line Number","Error Message"
+
+        "3760","line 3,760: Translation of
+        ""objectStateBehavior.glossary_definition_lifecycle__sys#approved_state__sys#change_state_to_draft_useraction1__sys.label""
+        not supported"
+
+        "3762","line 3,762: Translation of
+        ""objectStateBehavior.glossary_definition_lifecycle__sys#approved_state__sys#change_state_to_withdrawn_useraction__sys.label""
+        not supported"
+
+        "3764","line 3,764: Translation of
+        ""objectStateBehavior.glossary_definition_lifecycle__sys#draft_state__sys#change_state_to_in_review_useraction__sys.label""
+        not supported"
+
+        "3766","line 3,766: Translation of
+        ""objectStateBehavior.glossary_definition_lifecycle__sys#in_review_state__sys#change_state_to_approved_useraction__sys.label""
+        not supported"
+
+        "3768","line 3,768: Translation of
+        ""objectStateBehavior.glossary_definition_lifecycle__sys#in_review_state__sys#change_state_to_draft_useraction__sys.label""
+        not supported"
+
+        "3770","line 3,770: Translation of
+        ""objectStateBehavior.glossary_definition_lifecycle__sys#withdrawn_state__sys#change_state_to_draft_useraction2__sys.label""
+        not supported"
+
+         ```
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: text/csv
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: job_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/jobs/:{job_id}:
+    get:
+      tags:
+        - Jobs
+      summary: Retrieve Job Status
+      description: >+
+        https://developer.veevavault.com/api/25.1/#RetrieveJobStatus
+
+
+
+        After submitting a request, you can query your Vault to determine the
+        status of the request. To do this, you must have a valid `job_id` for a
+        job previously requested through the API.
+
+
+        Example Jobs:
+
+
+        * Binder Export
+
+        * Import Submission
+
+        * Export Submission
+
+        * Create EDL
+
+        * Deploy Package
+
+        * Deep Copy Object Record
+
+        * Cascade Delete Object Record
+
+        * Export Documents
+
+
+        **Note:** The <a
+        href="https://developer.veevavault.com/api/25.1/#RetrieveJobStatus">Job
+        Status</a> endpoint can only be requested once every 10 seconds. When
+        this limit is reached, Vault returns <code
+        class="prettyprint">API_LIMIT_EXCEEDED</code>.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: job_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/jobs/:{job_id}/tasks:
+    get:
+      tags:
+        - Jobs
+      summary: Retrieve SDK Job Tasks
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Job_Tasks
+
+
+        Retrieve the tasks associated with an SDK job.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: job_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/jobs/histories:
+    get:
+      tags:
+        - Jobs
+      summary: Retrieve Job Histories
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Job_Histories
+
+
+
+        Retrieve a history of all completed jobs in the authenticated Vault. A
+        completed job is any job which has started and finished running,
+        including jobs which did not complete successfully. In-progress or
+        queued jobs do not appear here.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: start_date
+          in: query
+          schema:
+            type: string
+          description: >-
+            Sets the date to start retrieving completed jobs, in the format
+            YYYY-MM-DDTHH:MM:SSZ. For example, for 7AM on January 15, 2016, use
+            2016-01-15T07:00:00Z. If omitted, defaults to the first completed
+            job.
+        - name: end_date
+          in: query
+          schema:
+            type: string
+          description: >-
+            Sets the date to end retrieving completed jobs, in the format
+            YYYY-MM-DDTHH:MM:SSZ. For example, for 7AM on January 15, 2016, use
+            2016-01-15T07:00:00Z. If omitted, defaults to the current date and
+            time.
+        - name: status
+          in: query
+          schema:
+            type: string
+          description: >-
+            Filter to only retrieve jobs in a certain status. Allowed values are
+            success, errors_encountered, failed_to_run, missed_schedule,
+            cancelled. If omitted, retrieves all statuses.
+        - name: limit
+          in: query
+          schema:
+            type: string
+          description: >-
+            Paginate the results by specifying the maximum number of histories
+            per page in the response. This can be any value between 1 and 200.
+            If omitted, defaults to 50.
+        - name: offset
+          in: query
+          schema:
+            type: string
+          description: >-
+            Paginate the results displayed per page by specifying the amount of
+            offset from the first job history returned. If omitted, defaults to
+            0. If you are viewing the first 50 results (page 1) and want to see
+            the next page, set this to offset=51.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/jobs/monitors:
+    get:
+      tags:
+        - Jobs
+      summary: Retrieve Job Monitors
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Job_Monitors
+
+
+
+        Retrieve monitors for jobs which have not yet completed in the
+        authenticated Vault. An uncompleted job is any job which has not
+        finished running, such as scheduled, queued, or actively running jobs.
+        Completed jobs do not appear here.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: start_date
+          in: query
+          schema:
+            type: string
+          description: >-
+            Sets the date to start retrieving uncompleted jobs, based on the
+            date and time the job instance was created. Value must be in the
+            format YYYY-MM-DDTHH:MM:SSZ. For example, for 7AM on January 15,
+            2016, use 2016-01-15T07:00:00Z. If omitted, defaults to the first
+            completed job.
+        - name: end_date
+          in: query
+          schema:
+            type: string
+          description: >-
+            Sets the date to end retrieving uncompleted jobs, based on the date
+            and time the job instance was created. Value must be in the format
+            YYYY-MM-DDTHH:MM:SSZ. For example, for 7AM on January 15, 2016, use
+            2016-01-15T07:00:00Z. If omitted, defaults to the current date and
+            time.
+        - name: status
+          in: query
+          schema:
+            type: string
+          description: >-
+            Filter to only retrieve jobs in a certain status. Allowed values are
+            scheduled, queued, running. If omitted, retrieves all statuses.
+        - name: limit
+          in: query
+          schema:
+            type: string
+          description: >-
+            Paginate the results by specifying the maximum number of jobs per
+            page in the response. This can be any value between 1 and 200. If
+            omitted, defaults to 50.
+        - name: offset
+          in: query
+          schema:
+            type: string
+          description: >-
+            Paginate the results displayed per page by specifying the amount of
+            offset from the first job instance returned. If omitted, defaults to
+            0. If you are viewing the first 50 results (page 1) and want to see
+            the next page, set this to offset=51.
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/jobs/start_now/:{job_id}:
+    post:
+      tags:
+        - Jobs
+      summary: Start Job
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Start_Job
+
+
+
+        Moves up a `scheduled` job instance to start immediately. Each time a
+        user calls this API, Vault cancels the next scheduled instance of the
+        specified job. For example, calling this API against a scheduled daily
+        job three times would cause the job to not run according to its schedule
+        for three days. Once the affected Job ID is complete, Vault will
+        schedule the next instance.
+
+
+        This is analogous to the *Start Now* option in the Vault UI.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: job_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/queues:
+    get:
+      tags:
+        - Managing Vault Java SDK > Queues
+      summary: Retrieve All Queues
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Retrieve_All_Queues
+
+
+        Retrieve all queues in a Vault.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/queues/:{queue_name}:
+    get:
+      tags:
+        - Managing Vault Java SDK > Queues
+      summary: Retrieve Queue Status
+      description: |+
+        https://developer.veevavault.com/api/25.1/#Retrieve_Queues_Status
+
+
+        Retrieve the status of a specific queue.
+
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: queue_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/queues/:{queue_name}/actions/disable_delivery:
+    put:
+      tags:
+        - Managing Vault Java SDK > Queues
+      summary: Disable Delivery
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Disable_Delivery
+
+
+
+        The following endpoint allows you to disable the delivery of messages in
+        an outbound Spark messaging queue, or an SDK job queue. This stop
+        messages from exiting the queue. For example, disabling delivery on an
+        SDK job queue stops messages from being delivered to the processor.
+
+
+        This endpoint is not available for inbound Spark messaging queues. There
+        is no way to stop received messages from processing in an inbound Spark
+        queue.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: queue_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/queues/:{queue_name}/actions/enable_delivery:
+    put:
+      tags:
+        - Managing Vault Java SDK > Queues
+      summary: Enable Delivery
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Enable_Delivery
+
+
+
+        The following endpoint allows you to enable the delivery of messages in
+        an outbound Spark messaging queue, or an SDK job queue. This allows
+        messages to exit the queue. For example, enabling delivery on an SDK job
+        queue allows messages to be delivered to the processor.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: queue_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/queues/:{queue_name}/actions/reset:
+    put:
+      tags:
+        - Managing Vault Java SDK > Queues
+      summary: Reset Queue
+      description: >+
+        https://developer.veevavault.com/api/25.1/#Reset_Queue
+
+
+
+        Delete all messages in a specific queue. This action is final and cannot
+        be undone.
+
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: queue_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/code/:{class_name}:
+    get:
+      tags:
+        - Managing Vault Java SDK
+      summary: Retrieve Single Source Code File
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Retrieve_Code
+
+
+        Retrieve a single source code file from the currently authenticated
+        Vault.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: class_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Managing Vault Java SDK
+      summary: Delete Single Source Code File
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Delete_Code
+
+
+        **Note:** We do not recommend using the following endpoint to deploy
+        code as you may introduce code which breaks existing deployed code. For
+        best practices, use the <a
+        href="https://developer.veevavault.com/sdk/#Deploy">VPK Deploy
+        method</a>.
+
+
+        Delete a single source code file from the currently authenticated Vault.
+        You cannot delete a code component currently in-use.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: class_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/code/:{class_name}/enable:
+    put:
+      tags:
+        - Managing Vault Java SDK
+      summary: Enable Vault Extension
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Enable_Disable_Code
+
+
+        Enable a deployed Vault extension in the currently authenticated vault.
+        Only available on entry-point classes, such as triggers and actions.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: multipart/form-data
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: class_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/code/:{class_name}/disable:
+    put:
+      tags:
+        - Managing Vault Java SDK
+      summary: Disable Vault Extension
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Enable_Disable_Code
+
+
+        Disable a deployed Vault extension in the currently authenticated vault.
+        Only available on entry-point classes, such as triggers and actions.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: multipart/form-data
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: class_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/code:
+    put:
+      tags:
+        - Managing Vault Java SDK
+      summary: Add or Replace Single Source Code File
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Add_Code
+
+
+        **Note:** We do not recommend using the following endpoint to deploy
+        code as you may introduce code which breaks existing deployed code. For
+        best practices, use the <a
+        href="https://developer.veevavault.com/sdk/#Deploy">VPK Deploy
+        method</a>.
+
+
+        Add or replace a single `.java` file in the currently authenticated
+        Vault. If the given file does not already exist in the Vault, it is
+        added. If the file already exists in the Vault, the file is updated.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: multipart/form-data
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/vobject/vault_package__v/:{package_id}/actions/validate:
+    post:
+      tags:
+        - Managing Vault Java SDK
+      summary: Validate Imported Package
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Validate_Imported_Code
+
+
+        Validate a previously imported VPK package with Vault Java SDK code.
+        Note that this endpoint does not validate component dependencies for
+        Configuration Migration packages.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: package_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/services/certificate/:{cert_id}:
+    get:
+      tags:
+        - Managing Vault Java SDK
+      summary: Retrieve Signing Certificate
+      description: >-
+        https://developer.veevavault.com/api/25.1/#Retrieve_Signing_Certificate
+
+
+        The following endpoint allows you to retrieve a signing certificate
+        included in a Spark message header to verify that the received message
+        came from Vault.
+      parameters:
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: cert_id
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/uicode/distributions:
+    get:
+      tags:
+        - Custom Pages
+      summary: Retrieve All Client Code Distribution Metadata
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Retrieve_All_Client_Code_Distribution_Metadata](https://developer.veevavault.com/api/25.1/#Retrieve_All_Client_Code_Distribution_Metadata)
+
+
+        Retrieves a list of all client code distributions in the Vault and their
+        metadata.
+
+
+        This endpoint does not retrieve the contents of distribution manifest
+        files.
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - Custom Pages
+      summary: Add or Replace Single Client Code Distribution
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Add_Replace_Single_Distribution](https://developer.veevavault.com/api/25.1/#Add_Replace_Single_Distribution)
+
+
+        Add or replace client code in Vault by uploading a ZIP file of the
+        client code distribution. Vault unpacks and compares the uploaded
+        distribution with other distributions in the Vault and:
+
+
+        - Adds the distribution if the distribution name is new.
+            
+        - Replaces a distribution if it has the same name and the client code
+        filenames or contents are different.
+            
+        - Makes no changes if the distribution name exists and the code is the
+        same.
+            
+
+        To upload the file, use the multi-part attachment with the file
+        component "file={file_name}". The maximum allowed total file size for
+        all distributions in a Vault is 50 MB.
+      requestBody:
+        content: {}
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: Content-Type
+          in: header
+          schema:
+            type: string
+          example: multipart/form-data
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/uicode/distributions/:{distribution_name}:
+    get:
+      tags:
+        - Custom Pages
+      summary: Retrieve Single Client Code Distribution Metadata
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Retrieve_Single_Client_Code_Distribution_Metadata](https://developer.veevavault.com/api/25.1/#Retrieve_Single_Client_Code_Distribution_Metadata)
+
+
+        Retrieve metadata for a specific client code distribution, including its
+        name and size.
+
+
+        This endpoint does not retrieve the contents of the distribution
+        manifest file.
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: distribution_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    delete:
+      tags:
+        - Custom Pages
+      summary: Delete Single Client Code Distribution
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Delete_Single_Client_Code_Distribution](https://developer.veevavault.com/api/25.1/#Delete_Single_Client_Code_Distribution)
+
+
+        Delete a specific client code distribution. To delete a distribution,
+        you must first remove all \`Page\` components associated with it from
+        your Vault.
+
+
+        To delete a single file from an existing distribution, re-package the
+        distribution without the file and re-[upload the distribution to
+        Vault](https://developer.veevavault.com/api/25.1/#Add_Replace_Single_Distribution).
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: distribution_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /api/{version}/uicode/distributions/:{distribution_name}/code:
+    get:
+      tags:
+        - Custom Pages
+      summary: Download Single Client Code Distribution
+      description: >-
+        [https://developer.veevavault.com/api/25.1/#Download_Single_Client_Code_Distribution](https://developer.veevavault.com/api/25.1/#Download_Single_Client_Code_Distribution)
+
+
+        Download a ZIP file containing the client code distribution directory,
+        including the client code files and the distribution manifest
+        (\`distribution-manifest.json\`).
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            type: string
+          example: application/json
+        - name: Authorization
+          in: header
+          schema:
+            type: string
+          example: '{{sessionId}}'
+        - name: X-VaultAPI-ClientID
+          in: header
+          schema:
+            type: string
+          description: >-
+            Include a Client ID to identify this request. This ID appears in the
+            API Usage Logs, which is avaiable to download from Admin > Logs >
+            API Usage Logs or through the Vault REST API with the Download Daily
+            API Usage request. If omitted, the value will appear as `unknown` in
+            the API Usage Log.
+          example: '{{clientId}}'
+        - name: version
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: distribution_name
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}


### PR DESCRIPTION
## Summary
- generate OpenAPI v3 spec from the Veeva Vault Postman collection

## Testing
- `node -e "const p=require('./node_modules/postman-to-openapi');p('veeva_vault/Veeva Vault API v25.1.postman_collection.json','veeva_vault/openapi.yaml',{defaultTag:'General'}).then(()=>console.log('success')).catch(console.error);"`

------
https://chatgpt.com/codex/tasks/task_e_686e9dccad6c832c9d70f1053e2eae28