### PR TITLE
Add OpenAPI generator workflow

### DIFF
--- a/.github/workflows/openapi-generate.yml
+++ b/.github/workflows/openapi-generate.yml
@@ -1,0 +1,62 @@
+name: Validate and Generate SDKs
+
+on:
+  push:
+    paths:
+      - 'veeva_vault/openapi.yaml'
+      - 'imednet/openapi.yaml'
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Validate iMednet specification
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/local openapitools/openapi-generator-cli validate -i /local/imednet/openapi.yaml
+      - name: Validate Veeva Vault specification
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/local openapitools/openapi-generator-cli validate -i /local/veeva_vault/openapi.yaml
+
+  generate-imednet:
+    needs: validate
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        language: [c, csharp, dart, go, java, javascript, python, r, ruby, rust]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate ${{ matrix.language }} client for iMednet
+        run: |
+          mkdir -p imednet/${{ matrix.language }}
+          docker run --rm -u $(id -u):$(id -g) -v ${{ github.workspace }}:/local \
+            openapitools/openapi-generator-cli generate \
+            -i /local/imednet/openapi.yaml \
+            -g ${{ matrix.language }} \
+            -o /local/imednet/${{ matrix.language }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: imednet-${{ matrix.language }}
+          path: imednet/${{ matrix.language }}
+
+  generate-veeva:
+    needs: validate
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        language: [c, csharp, dart, go, java, javascript, python, r, ruby, rust]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate ${{ matrix.language }} client for Veeva Vault
+        run: |
+          mkdir -p veeva_vault/${{ matrix.language }}
+          docker run --rm -u $(id -u):$(id -g) -v ${{ github.workspace }}:/local \
+            openapitools/openapi-generator-cli generate \
+            -i /local/veeva_vault/openapi.yaml \
+            -g ${{ matrix.language }} \
+            -o /local/veeva_vault/${{ matrix.language }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: veeva-${{ matrix.language }}
+          path: veeva_vault/${{ matrix.language }}


### PR DESCRIPTION
## Summary
- add CI workflow to validate OpenAPI specs for iMednet and Veeva
- generate language SDKs for both APIs using openapi-generator

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686ea9007238832c906b4d515bc45351