### PR TITLE
Split GitHub Actions into separate workflows

### DIFF
--- a/.github/workflows/openapi-imednet.yml
+++ b/.github/workflows/openapi-imednet.yml
@@ -1,26 +1,22 @@
-name: Validate and Generate SDKs
+name: Validate and Generate iMednet SDKs
 
 on:
   push:
     paths:
-      - 'veeva_vault/openapi.yaml'
       - 'imednet/openapi.yaml'
   workflow_dispatch:
 
 jobs:
-  validate:
+  validate-imednet:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Validate iMednet specification
         run: |
           docker run --rm -v ${{ github.workspace }}:/local openapitools/openapi-generator-cli validate -i /local/imednet/openapi.yaml
-      - name: Validate Veeva Vault specification
-        run: |
-          docker run --rm -v ${{ github.workspace }}:/local openapitools/openapi-generator-cli validate -i /local/veeva_vault/openapi.yaml
 
   generate-imednet:
-    needs: validate
+    needs: validate-imednet
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -39,24 +35,3 @@ jobs:
         with:
           name: imednet-${{ matrix.language }}
           path: imednet/${{ matrix.language }}
-
-  generate-veeva:
-    needs: validate
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        language: [c, csharp, dart, go, java, javascript, python, r, ruby, rust]
-    steps:
-      - uses: actions/checkout@v3
-      - name: Generate ${{ matrix.language }} client for Veeva Vault
-        run: |
-          mkdir -p veeva_vault/${{ matrix.language }}
-          docker run --rm -u $(id -u):$(id -g) -v ${{ github.workspace }}:/local \
-            openapitools/openapi-generator-cli generate \
-            -i /local/veeva_vault/openapi.yaml \
-            -g ${{ matrix.language }} \
-            -o /local/veeva_vault/${{ matrix.language }}
-      - uses: actions/upload-artifact@v3
-        with:
-          name: veeva-${{ matrix.language }}
-          path: veeva_vault/${{ matrix.language }}

--- a/.github/workflows/openapi-veeva.yml
+++ b/.github/workflows/openapi-veeva.yml
@@ -1,0 +1,37 @@
+name: Validate and Generate Veeva Vault SDKs
+
+on:
+  push:
+    paths:
+      - 'veeva_vault/openapi.yaml'
+  workflow_dispatch:
+
+jobs:
+  validate-veeva:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Validate Veeva Vault specification
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/local openapitools/openapi-generator-cli validate -i /local/veeva_vault/openapi.yaml
+
+  generate-veeva:
+    needs: validate-veeva
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        language: [c, csharp, dart, go, java, javascript, python, r, ruby, rust]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate ${{ matrix.language }} client for Veeva Vault
+        run: |
+          mkdir -p veeva_vault/${{ matrix.language }}
+          docker run --rm -u $(id -u):$(id -g) -v ${{ github.workspace }}:/local \
+            openapitools/openapi-generator-cli generate \
+            -i /local/veeva_vault/openapi.yaml \
+            -g ${{ matrix.language }} \
+            -o /local/veeva_vault/${{ matrix.language }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: veeva-${{ matrix.language }}
+          path: veeva_vault/${{ matrix.language }}


### PR DESCRIPTION
## Summary
- split the combined workflow into two
  - `openapi-imednet.yml` handles validation and client generation for iMednet
  - `openapi-veeva.yml` handles Veeva Vault validation and client generation

## Testing
- `yamllint .github/workflows/openapi-imednet.yml`
- `yamllint .github/workflows/openapi-veeva.yml`

------
https://chatgpt.com/codex/tasks/task_e_686eaeb7b178832c8751878f5c4a4048