### PR TITLE
Add workflow to sync iMednet spec with Postman

### DIFF
--- a/.github/workflows/openapi-imednet-postman.yml
+++ b/.github/workflows/openapi-imednet-postman.yml
@@ -1,0 +1,36 @@
+name: Update iMednet Postman Collection
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'imednet/openapi.yaml'
+
+jobs:
+  generate-postman:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install openapi-to-postmanv2
+        run: npm install -g openapi-to-postmanv2
+      - name: Convert iMednet OpenAPI spec to Postman collection
+        run: |
+          openapi2postmanv2 -s imednet/openapi.yaml -o imednet/postman_collection.json -p -O folderStrategy=Tags
+          jq -n --slurpfile c imednet/postman_collection.json '{collection: $c[0]}' > imednet/postman_request.json
+      - name: Upload Postman collection
+        env:
+          POSTMAN_API_KEY: ${{ secrets.POSTMAN_API_KEY }}
+          POSTMAN_COLLECTION_UID: ${{ secrets.POSTMAN_COLLECTION_UID }}
+        run: |
+          curl -X PUT "https://api.getpostman.com/collections/${POSTMAN_COLLECTION_UID}" \
+            -H "X-API-Key: ${POSTMAN_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d @imednet/postman_request.json
+      - uses: actions/upload-artifact@v3
+        with:
+          name: imednet-postman-collection
+          path: imednet/postman_collection.json

--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ This repository hosts OpenAPI specifications for two clinical research platforms
 - **iMednet EDC API**: see `imednet/openapi.yaml` and the accompanying RST documentation under `imednet/api_docs`.
 - **Veeva Vault API**: specification generated from the Veeva Vault Postman collection located in `veeva_vault/openapi.yaml`.
 
-A GitHub Actions workflow (`.github/workflows/openapi-generate.yml`) validates the specifications and can produce client SDKs in several languages using OpenAPI Generator.
+GitHub Actions workflows validate the specifications and can produce client SDKs in several languages using OpenAPI Generator. An additional workflow converts the iMednet specification into a Postman collection and updates it via the Postman API.
 


### PR DESCRIPTION
## Summary
- add a workflow that converts the iMednet OpenAPI spec to a Postman collection and uploads it
- update README with note about new workflow

## Testing
- `npm view openapi-to-postmanv2 version`


------
https://chatgpt.com/codex/tasks/task_e_686eb0dde350832caeb15ed5c3d42b99