### PR TITLE
Fix deprecated upload artifact version

### DIFF
--- a/.github/workflows/openapi-imednet.yml
+++ b/.github/workflows/openapi-imednet.yml
@@ -31,7 +31,7 @@ jobs:
             -i /local/imednet/openapi.yaml \
             -g ${{ matrix.language }} \
             -o /local/imednet/${{ matrix.language }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: imednet-${{ matrix.language }}
           path: imednet/${{ matrix.language }}

--- a/.github/workflows/openapi-veeva.yml
+++ b/.github/workflows/openapi-veeva.yml
@@ -31,7 +31,7 @@ jobs:
             -i /local/veeva_vault/openapi.yaml \
             -g ${{ matrix.language }} \
             -o /local/veeva_vault/${{ matrix.language }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: veeva-${{ matrix.language }}
           path: veeva_vault/${{ matrix.language }}


### PR DESCRIPTION
## Summary
- upgrade `actions/upload-artifact` to `v4` in GitHub workflows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eb1c2a304832c98b7c1f487a4d88c