### PR TITLE
Save generated Postman collection to repo

### DIFF
--- a/.github/workflows/openapi-imednet-postman.yml
+++ b/.github/workflows/openapi-imednet-postman.yml
@@ -1,0 +1,27 @@
+name: Generate iMednet Postman Collection
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'imednet/openapi.yaml'
+
+jobs:
+  generate-postman:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install openapi-to-postmanv2
+        run: npm install -g openapi-to-postmanv2
+      - name: Convert iMednet OpenAPI spec to Postman collection
+        run: |
+          mkdir -p imednet/postman
+          openapi2postmanv2 -s imednet/openapi.yaml -o imednet/postman/collection.json -p -O folderStrategy=Tags
+      - uses: EndBug/add-and-commit@v9
+        with:
+          add: imednet/postman/collection.json
+          message: Update generated iMednet Postman collection

--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ This repository hosts OpenAPI specifications for two clinical research platforms
 - **iMednet EDC API**: see `imednet/openapi.yaml` and the accompanying RST documentation under `imednet/api_docs`.
 - **Veeva Vault API**: specification generated from the Veeva Vault Postman collection located in `veeva_vault/openapi.yaml`.
 
-A GitHub Actions workflow (`.github/workflows/openapi-generate.yml`) validates the specifications and can produce client SDKs in several languages using OpenAPI Generator.
+GitHub Actions workflows validate the specifications and can produce client SDKs in several languages using OpenAPI Generator. Another workflow converts the iMednet specification into a Postman collection stored under `imednet/postman/collection.json`.
 

--- a/imednet/postman/collection.json
+++ b/imednet/postman/collection.json
@@ -1,0 +1,4655 @@
+{
+    "item": [
+        {
+            "id": "35f5ec7a-aa69-4907-a49c-b79ed6832e4c",
+            "name": "List studies",
+            "request": {
+                "name": "List studies",
+                "description": {
+                    "content": "Returns metadata for studies the API key can access.\nFilter attributes: ``studyKey``, ``studyType``, ``studyName``,\n``dateCreated`` and ``dateModified``.\n",
+                    "type": "text/plain"
+                },
+                "url": {
+                    "path": [
+                        "studies"
+                    ],
+                    "host": [
+                        "{{baseUrl}}"
+                    ],
+                    "query": [
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "page",
+                            "value": "0"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "size",
+                            "value": "25"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "sort",
+                            "value": "studyKey,asc"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "filter",
+                            "value": "<string>"
+                        }
+                    ],
+                    "variable": []
+                },
+                "header": [
+                    {
+                        "key": "Accept",
+                        "value": "application/json"
+                    }
+                ],
+                "method": "GET",
+                "body": {},
+                "auth": null
+            },
+            "response": [
+                {
+                    "id": "6091f269-1362-4716-898e-743f08574d24",
+                    "name": "List of studies",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "studyKey,asc"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "OK",
+                    "code": 200,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"sponsorKey\": \"<string>\",\n      \"studyKey\": \"<string>\",\n      \"studyId\": \"<integer>\",\n      \"studyName\": \"<string>\",\n      \"studyDescription\": \"<string>\",\n      \"studyType\": \"<string>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    },\n    {\n      \"sponsorKey\": \"<string>\",\n      \"studyKey\": \"<string>\",\n      \"studyId\": \"<integer>\",\n      \"studyName\": \"<string>\",\n      \"studyDescription\": \"<string>\",\n      \"studyType\": \"<string>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    }\n  ]\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "89dbf0c9-0671-4653-94d4-1349e7a973cc",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "studyKey,asc"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Bad Request",
+                    "code": 400,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "b6343cfa-f9d5-465c-a4c7-f01cea661c84",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "studyKey,asc"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Unauthorized",
+                    "code": 401,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                }
+            ],
+            "event": [],
+            "protocolProfileBehavior": {
+                "disableBodyPruning": true
+            }
+        },
+        {
+            "id": "e9a69a0d-325a-40ab-9e5f-1cf076c57e25",
+            "name": "Retrieve a study",
+            "request": {
+                "name": "Retrieve a study",
+                "description": {
+                    "content": "Return metadata for the specified study.",
+                    "type": "text/plain"
+                },
+                "url": {
+                    "path": [
+                        "studies",
+                        ":studyKey"
+                    ],
+                    "host": [
+                        "{{baseUrl}}"
+                    ],
+                    "query": [],
+                    "variable": [
+                        {
+                            "type": "any",
+                            "value": "<string>",
+                            "key": "studyKey",
+                            "disabled": false,
+                            "description": {
+                                "content": "(Required) ",
+                                "type": "text/plain"
+                            }
+                        }
+                    ]
+                },
+                "header": [
+                    {
+                        "key": "Accept",
+                        "value": "application/json"
+                    }
+                ],
+                "method": "GET",
+                "body": {},
+                "auth": null
+            },
+            "response": [
+                {
+                    "id": "152f4805-744d-4aa5-9a2d-9ec47ae91e11",
+                    "name": "Study information",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "OK",
+                    "code": 200,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"sponsorKey\": \"<string>\",\n  \"studyKey\": \"<string>\",\n  \"studyId\": \"<integer>\",\n  \"studyName\": \"<string>\",\n  \"studyDescription\": \"<string>\",\n  \"studyType\": \"<string>\",\n  \"dateCreated\": \"<string>\",\n  \"dateModified\": \"<string>\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "a92a2d75-6171-4393-be39-58bf5920a834",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Bad Request",
+                    "code": 400,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "c8ea1687-0f27-4723-8314-8f7a6fdf092a",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Unauthorized",
+                    "code": 401,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                }
+            ],
+            "event": [],
+            "protocolProfileBehavior": {
+                "disableBodyPruning": true
+            }
+        },
+        {
+            "id": "5fdc818c-31de-45b6-83ac-9c51000bb267",
+            "name": "List forms",
+            "request": {
+                "name": "List forms",
+                "description": {
+                    "content": "Returns the design specifications for eCRFs in the study.\nFilter attributes: ``formId``, ``formKey``, ``formName``,\n``formType``, ``dateCreated`` and ``dateModified``.\n",
+                    "type": "text/plain"
+                },
+                "url": {
+                    "path": [
+                        "studies",
+                        ":studyKey",
+                        "forms"
+                    ],
+                    "host": [
+                        "{{baseUrl}}"
+                    ],
+                    "query": [
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "page",
+                            "value": "0"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "size",
+                            "value": "25"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "sort",
+                            "value": "<string>"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                "type": "text/plain"
+                            },
+                            "key": "filter",
+                            "value": "<string>"
+                        }
+                    ],
+                    "variable": [
+                        {
+                            "type": "any",
+                            "value": "<string>",
+                            "key": "studyKey",
+                            "disabled": false,
+                            "description": {
+                                "content": "(Required) ",
+                                "type": "text/plain"
+                            }
+                        }
+                    ]
+                },
+                "header": [
+                    {
+                        "key": "Accept",
+                        "value": "application/json"
+                    }
+                ],
+                "method": "GET",
+                "body": {},
+                "auth": null
+            },
+            "response": [
+                {
+                    "id": "d7a165e9-863c-42a2-afb3-3d4fca5c4146",
+                    "name": "List of forms",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "forms"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "OK",
+                    "code": 200,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"formId\": \"<integer>\",\n      \"formKey\": \"<string>\",\n      \"formName\": \"<string>\",\n      \"formType\": \"<string>\",\n      \"revision\": \"<integer>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"formId\": \"<integer>\",\n      \"formKey\": \"<string>\",\n      \"formName\": \"<string>\",\n      \"formType\": \"<string>\",\n      \"revision\": \"<integer>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    }\n  ]\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "9c8a0532-e534-420e-8e0a-1f52615934e0",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "forms"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Bad Request",
+                    "code": 400,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "71c6fb7b-0ad2-4731-923b-7aa7ff7f2abe",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "forms"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Unauthorized",
+                    "code": 401,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                }
+            ],
+            "event": [],
+            "protocolProfileBehavior": {
+                "disableBodyPruning": true
+            }
+        },
+        {
+            "id": "fadf8a5c-b98d-428f-af53-0c17dcd2c62e",
+            "name": "List variables",
+            "request": {
+                "name": "List variables",
+                "description": {
+                    "content": "Retrieves variables representing eCRF fields for the study.\nFilter attributes: ``variableId``, ``variableType``, ``variableName``,\n``dateCreated``, ``dateModified``, ``formId``, ``formKey``,\n``formName`` and ``label``.\n",
+                    "type": "text/plain"
+                },
+                "url": {
+                    "path": [
+                        "studies",
+                        ":studyKey",
+                        "variables"
+                    ],
+                    "host": [
+                        "{{baseUrl}}"
+                    ],
+                    "query": [
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "page",
+                            "value": "0"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "size",
+                            "value": "25"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "sort",
+                            "value": "<string>"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                "type": "text/plain"
+                            },
+                            "key": "filter",
+                            "value": "<string>"
+                        }
+                    ],
+                    "variable": [
+                        {
+                            "type": "any",
+                            "value": "<string>",
+                            "key": "studyKey",
+                            "disabled": false,
+                            "description": {
+                                "content": "(Required) ",
+                                "type": "text/plain"
+                            }
+                        }
+                    ]
+                },
+                "header": [
+                    {
+                        "key": "Accept",
+                        "value": "application/json"
+                    }
+                ],
+                "method": "GET",
+                "body": {},
+                "auth": null
+            },
+            "response": [
+                {
+                    "id": "65a54b1f-2722-4eb6-894f-25cb9c5149b3",
+                    "name": "Variable list",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "variables"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "OK",
+                    "code": 200,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"variableId\": \"<integer>\",\n      \"variableType\": \"<string>\",\n      \"variableName\": \"<string>\",\n      \"sequence\": \"<integer>\",\n      \"revision\": \"<integer>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\",\n      \"formId\": \"<integer>\",\n      \"formKey\": \"<string>\",\n      \"formName\": \"<string>\"\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"variableId\": \"<integer>\",\n      \"variableType\": \"<string>\",\n      \"variableName\": \"<string>\",\n      \"sequence\": \"<integer>\",\n      \"revision\": \"<integer>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\",\n      \"formId\": \"<integer>\",\n      \"formKey\": \"<string>\",\n      \"formName\": \"<string>\"\n    }\n  ]\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "9f06fbd3-b33f-405b-a197-2a548762e439",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "variables"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Bad Request",
+                    "code": 400,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "b800bfba-d754-46fb-9647-315090d1b9e8",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "variables"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Unauthorized",
+                    "code": 401,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                }
+            ],
+            "event": [],
+            "protocolProfileBehavior": {
+                "disableBodyPruning": true
+            }
+        },
+        {
+            "id": "a9a7156d-7787-404b-a4ce-981f369f8ab3",
+            "name": "List intervals",
+            "request": {
+                "name": "List intervals",
+                "description": {
+                    "content": "Lists scheduled intervals or visits defined for the study.\nFilter attributes: ``intervalId``, ``intervalName``, ``intervalGroupId``,\n``intervalGroupName``, ``dateCreated`` and ``dateModified``.\n",
+                    "type": "text/plain"
+                },
+                "url": {
+                    "path": [
+                        "studies",
+                        ":studyKey",
+                        "intervals"
+                    ],
+                    "host": [
+                        "{{baseUrl}}"
+                    ],
+                    "query": [
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "page",
+                            "value": "0"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "size",
+                            "value": "25"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "sort",
+                            "value": "<string>"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                "type": "text/plain"
+                            },
+                            "key": "filter",
+                            "value": "<string>"
+                        }
+                    ],
+                    "variable": [
+                        {
+                            "type": "any",
+                            "value": "<string>",
+                            "key": "studyKey",
+                            "disabled": false,
+                            "description": {
+                                "content": "(Required) ",
+                                "type": "text/plain"
+                            }
+                        }
+                    ]
+                },
+                "header": [
+                    {
+                        "key": "Accept",
+                        "value": "application/json"
+                    }
+                ],
+                "method": "GET",
+                "body": {},
+                "auth": null
+            },
+            "response": [
+                {
+                    "id": "2e2a63fa-8926-4920-b08b-926e14859fdb",
+                    "name": "Interval list",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "intervals"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "OK",
+                    "code": 200,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"intervalId\": \"<integer>\",\n      \"intervalName\": \"<string>\",\n      \"intervalDescription\": \"<string>\",\n      \"intervalSequence\": \"<integer>\",\n      \"intervalGroupId\": \"<integer>\",\n      \"intervalGroupName\": \"<string>\",\n      \"disabled\": \"<boolean>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"intervalId\": \"<integer>\",\n      \"intervalName\": \"<string>\",\n      \"intervalDescription\": \"<string>\",\n      \"intervalSequence\": \"<integer>\",\n      \"intervalGroupId\": \"<integer>\",\n      \"intervalGroupName\": \"<string>\",\n      \"disabled\": \"<boolean>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    }\n  ]\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "a10b6d13-d55e-4e01-9b07-daaca385e725",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "intervals"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Bad Request",
+                    "code": 400,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "33f56cd8-79c1-401f-9a05-811f6f702a4f",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "intervals"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Unauthorized",
+                    "code": 401,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                }
+            ],
+            "event": [],
+            "protocolProfileBehavior": {
+                "disableBodyPruning": true
+            }
+        },
+        {
+            "id": "04b10a32-3cc9-4b03-8479-0356356904f5",
+            "name": "List sites",
+            "request": {
+                "name": "List sites",
+                "description": {
+                    "content": "Returns the set of sites participating in the study.\nFilter attributes: ``siteId``, ``siteName``, ``siteEnrollmentStatus``,\n``dateCreated`` and ``dateModified``.\n",
+                    "type": "text/plain"
+                },
+                "url": {
+                    "path": [
+                        "studies",
+                        ":studyKey",
+                        "sites"
+                    ],
+                    "host": [
+                        "{{baseUrl}}"
+                    ],
+                    "query": [
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "page",
+                            "value": "0"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "size",
+                            "value": "25"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "sort",
+                            "value": "<string>"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                "type": "text/plain"
+                            },
+                            "key": "filter",
+                            "value": "<string>"
+                        }
+                    ],
+                    "variable": [
+                        {
+                            "type": "any",
+                            "value": "<string>",
+                            "key": "studyKey",
+                            "disabled": false,
+                            "description": {
+                                "content": "(Required) ",
+                                "type": "text/plain"
+                            }
+                        }
+                    ]
+                },
+                "header": [
+                    {
+                        "key": "Accept",
+                        "value": "application/json"
+                    }
+                ],
+                "method": "GET",
+                "body": {},
+                "auth": null
+            },
+            "response": [
+                {
+                    "id": "958b59fd-c48e-4cc1-be39-4e639ac6a5dc",
+                    "name": "Site list",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "sites"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "OK",
+                    "code": 200,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"siteName\": \"<string>\",\n      \"siteEnrollmentStatus\": \"<string>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"siteName\": \"<string>\",\n      \"siteEnrollmentStatus\": \"<string>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    }\n  ]\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "6e533b4c-bc24-4901-a9e3-eced44f3fde0",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "sites"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Bad Request",
+                    "code": 400,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "53d42d55-dfb7-4a19-97fe-0ec739225c2e",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "sites"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Unauthorized",
+                    "code": 401,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                }
+            ],
+            "event": [],
+            "protocolProfileBehavior": {
+                "disableBodyPruning": true
+            }
+        },
+        {
+            "id": "64f818c3-1d7a-4c65-914c-191bc85b4619",
+            "name": "List subjects",
+            "request": {
+                "name": "List subjects",
+                "description": {
+                    "content": "Returns all subjects enrolled in the study.",
+                    "type": "text/plain"
+                },
+                "url": {
+                    "path": [
+                        "studies",
+                        ":studyKey",
+                        "subjects"
+                    ],
+                    "host": [
+                        "{{baseUrl}}"
+                    ],
+                    "query": [
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "page",
+                            "value": "0"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "size",
+                            "value": "25"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "sort",
+                            "value": "<string>"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                "type": "text/plain"
+                            },
+                            "key": "filter",
+                            "value": "<string>"
+                        }
+                    ],
+                    "variable": [
+                        {
+                            "type": "any",
+                            "value": "<string>",
+                            "key": "studyKey",
+                            "disabled": false,
+                            "description": {
+                                "content": "(Required) ",
+                                "type": "text/plain"
+                            }
+                        }
+                    ]
+                },
+                "header": [
+                    {
+                        "key": "Accept",
+                        "value": "application/json"
+                    }
+                ],
+                "method": "GET",
+                "body": {},
+                "auth": null
+            },
+            "response": [
+                {
+                    "id": "0ffe7b1c-f2ef-4eab-af20-e26028495cbf",
+                    "name": "Subject list",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "subjects"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "OK",
+                    "code": 200,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectKey\": \"<string>\",\n      \"subjectStatus\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"siteName\": \"<string>\",\n      \"deleted\": \"<boolean>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectKey\": \"<string>\",\n      \"subjectStatus\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"siteName\": \"<string>\",\n      \"deleted\": \"<boolean>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    }\n  ]\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "98394c34-97e2-4ec0-8dda-f4a5f4a6231f",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "subjects"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Bad Request",
+                    "code": 400,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "902f7739-0439-4a2a-b8fc-3f5e4f24b646",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "subjects"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Unauthorized",
+                    "code": 401,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                }
+            ],
+            "event": [],
+            "protocolProfileBehavior": {
+                "disableBodyPruning": true
+            }
+        },
+        {
+            "id": "7cdf5055-4f46-429e-9363-b96f124e310b",
+            "name": "List records",
+            "request": {
+                "name": "List records",
+                "description": {
+                    "content": "Returns eCRF record instances for the study.\nFilter attributes: ``intervalId``, ``formId``, ``formKey``, ``siteId``,\n``recordId``, ``parentRecordId``, ``recordType``, ``recordStatus``,\n``subjectKey``, ``dateCreated`` and ``dateModified``.\n",
+                    "type": "text/plain"
+                },
+                "url": {
+                    "path": [
+                        "studies",
+                        ":studyKey",
+                        "records"
+                    ],
+                    "host": [
+                        "{{baseUrl}}"
+                    ],
+                    "query": [
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "page",
+                            "value": "0"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "size",
+                            "value": "25"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "sort",
+                            "value": "<string>"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                "type": "text/plain"
+                            },
+                            "key": "filter",
+                            "value": "<string>"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "Search criteria for values within ``recordData``. Supports the\nsame operators as ``filter`` with the addition of ``=~`` for\ncase-insensitive contains. Separate multiple conditions with\n``;`` for AND or ``,`` for OR but do not mix both connectors in\none request.\n",
+                                "type": "text/plain"
+                            },
+                            "key": "recordDataFilter",
+                            "value": "<string>"
+                        }
+                    ],
+                    "variable": [
+                        {
+                            "type": "any",
+                            "value": "<string>",
+                            "key": "studyKey",
+                            "disabled": false,
+                            "description": {
+                                "content": "(Required) ",
+                                "type": "text/plain"
+                            }
+                        }
+                    ]
+                },
+                "header": [
+                    {
+                        "key": "Accept",
+                        "value": "application/json"
+                    }
+                ],
+                "method": "GET",
+                "body": {},
+                "auth": null
+            },
+            "response": [
+                {
+                    "id": "0271ad9c-7452-4971-915c-7ad275367eee",
+                    "name": "Record list",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "records"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Search criteria for values within ``recordData``. Supports the\nsame operators as ``filter`` with the addition of ``=~`` for\ncase-insensitive contains. Separate multiple conditions with\n``;`` for AND or ``,`` for OR but do not mix both connectors in\none request.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "recordDataFilter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "OK",
+                    "code": 200,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"intervalId\": \"<integer>\",\n      \"formId\": \"<integer>\",\n      \"formKey\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"recordId\": \"<integer>\",\n      \"recordOid\": \"<string>\",\n      \"recordType\": \"<string>\",\n      \"recordStatus\": \"<string>\",\n      \"deleted\": \"<boolean>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectOid\": \"<string>\",\n      \"subjectKey\": \"<string>\",\n      \"visitId\": \"<integer>\",\n      \"parentRecordId\": \"<integer>\",\n      \"recordData\": {}\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"intervalId\": \"<integer>\",\n      \"formId\": \"<integer>\",\n      \"formKey\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"recordId\": \"<integer>\",\n      \"recordOid\": \"<string>\",\n      \"recordType\": \"<string>\",\n      \"recordStatus\": \"<string>\",\n      \"deleted\": \"<boolean>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectOid\": \"<string>\",\n      \"subjectKey\": \"<string>\",\n      \"visitId\": \"<integer>\",\n      \"parentRecordId\": \"<integer>\",\n      \"recordData\": {}\n    }\n  ]\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "1e75c934-54ea-4825-9f48-c0f46012c60d",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "records"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Search criteria for values within ``recordData``. Supports the\nsame operators as ``filter`` with the addition of ``=~`` for\ncase-insensitive contains. Separate multiple conditions with\n``;`` for AND or ``,`` for OR but do not mix both connectors in\none request.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "recordDataFilter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Bad Request",
+                    "code": 400,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "17d2cd9b-6c6e-4ff7-b652-8c56a4105b7a",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "records"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Search criteria for values within ``recordData``. Supports the\nsame operators as ``filter`` with the addition of ``=~`` for\ncase-insensitive contains. Separate multiple conditions with\n``;`` for AND or ``,`` for OR but do not mix both connectors in\none request.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "recordDataFilter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Unauthorized",
+                    "code": 401,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                }
+            ],
+            "event": [],
+            "protocolProfileBehavior": {
+                "disableBodyPruning": true
+            }
+        },
+        {
+            "id": "03dfb228-6bba-4c72-babf-a137528eac14",
+            "name": "Create records",
+            "request": {
+                "name": "Create records",
+                "description": {
+                    "content": "Adds new records and returns a job for asynchronous processing.",
+                    "type": "text/plain"
+                },
+                "url": {
+                    "path": [
+                        "studies",
+                        ":studyKey",
+                        "records"
+                    ],
+                    "host": [
+                        "{{baseUrl}}"
+                    ],
+                    "query": [],
+                    "variable": [
+                        {
+                            "type": "any",
+                            "value": "<string>",
+                            "key": "studyKey",
+                            "disabled": false,
+                            "description": {
+                                "content": "(Required) ",
+                                "type": "text/plain"
+                            }
+                        }
+                    ]
+                },
+                "header": [
+                    {
+                        "key": "Content-Type",
+                        "value": "application/json"
+                    },
+                    {
+                        "key": "Accept",
+                        "value": "application/json"
+                    }
+                ],
+                "method": "POST",
+                "body": {
+                    "mode": "raw",
+                    "raw": "[\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  },\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  }\n]",
+                    "options": {
+                        "raw": {
+                            "headerFamily": "json",
+                            "language": "json"
+                        }
+                    }
+                },
+                "auth": null
+            },
+            "response": [
+                {
+                    "id": "d3961362-74ea-40d0-bd6f-bd101957a133",
+                    "name": "Job created",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "records"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "POST",
+                        "body": {
+                            "mode": "raw",
+                            "raw": "[\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  },\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  }\n]",
+                            "options": {
+                                "raw": {
+                                    "headerFamily": "json",
+                                    "language": "json"
+                                }
+                            }
+                        }
+                    },
+                    "status": "Accepted",
+                    "code": 202,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"jobId\": \"<string>\",\n  \"batchId\": \"<string>\",\n  \"state\": \"<string>\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "e3b19084-cf3d-4bc0-8828-0c195e5d984a",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "records"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "POST",
+                        "body": {
+                            "mode": "raw",
+                            "raw": "[\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  },\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  }\n]",
+                            "options": {
+                                "raw": {
+                                    "headerFamily": "json",
+                                    "language": "json"
+                                }
+                            }
+                        }
+                    },
+                    "status": "Bad Request",
+                    "code": 400,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "587dab99-3c43-4dce-bcd0-e2ad9c422659",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "records"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Content-Type",
+                                "value": "application/json"
+                            },
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "POST",
+                        "body": {
+                            "mode": "raw",
+                            "raw": "[\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  },\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  }\n]",
+                            "options": {
+                                "raw": {
+                                    "headerFamily": "json",
+                                    "language": "json"
+                                }
+                            }
+                        }
+                    },
+                    "status": "Unauthorized",
+                    "code": 401,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                }
+            ],
+            "event": [],
+            "protocolProfileBehavior": {
+                "disableBodyPruning": true
+            }
+        },
+        {
+            "id": "bab57c2f-e90b-46c2-ade2-a3f14bfc1650",
+            "name": "List record revisions",
+            "request": {
+                "name": "List record revisions",
+                "description": {
+                    "content": "Returns revision history for records in the study.\nFilter attributes: ``recordRevisionId``, ``recordId``, ``recordOid``,\n``recordRevision``, ``dataRevision``, ``recordStatus``, ``user``,\n``reasonForChange`` and ``dateCreated``.\n",
+                    "type": "text/plain"
+                },
+                "url": {
+                    "path": [
+                        "studies",
+                        ":studyKey",
+                        "recordRevisions"
+                    ],
+                    "host": [
+                        "{{baseUrl}}"
+                    ],
+                    "query": [
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "page",
+                            "value": "0"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "size",
+                            "value": "25"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "sort",
+                            "value": "<string>"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                "type": "text/plain"
+                            },
+                            "key": "filter",
+                            "value": "<string>"
+                        }
+                    ],
+                    "variable": [
+                        {
+                            "type": "any",
+                            "value": "<string>",
+                            "key": "studyKey",
+                            "disabled": false,
+                            "description": {
+                                "content": "(Required) ",
+                                "type": "text/plain"
+                            }
+                        }
+                    ]
+                },
+                "header": [
+                    {
+                        "key": "Accept",
+                        "value": "application/json"
+                    }
+                ],
+                "method": "GET",
+                "body": {},
+                "auth": null
+            },
+            "response": [
+                {
+                    "id": "91b9d123-3599-4b70-a92d-349bfa71364f",
+                    "name": "Record revision list",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "recordRevisions"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "OK",
+                    "code": 200,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"recordRevisionId\": \"<integer>\",\n      \"recordId\": \"<integer>\",\n      \"recordRevision\": \"<integer>\",\n      \"dataRevision\": \"<integer>\",\n      \"recordStatus\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectKey\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"formKey\": \"<string>\",\n      \"intervalId\": \"<integer>\",\n      \"deleted\": \"<boolean>\",\n      \"dateCreated\": \"<string>\"\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"recordRevisionId\": \"<integer>\",\n      \"recordId\": \"<integer>\",\n      \"recordRevision\": \"<integer>\",\n      \"dataRevision\": \"<integer>\",\n      \"recordStatus\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectKey\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"formKey\": \"<string>\",\n      \"intervalId\": \"<integer>\",\n      \"deleted\": \"<boolean>\",\n      \"dateCreated\": \"<string>\"\n    }\n  ]\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "bad51872-5553-4bbd-98a4-19c15c611c83",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "recordRevisions"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Bad Request",
+                    "code": 400,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "37eeb863-e4fc-467b-aed1-f4b415423908",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "recordRevisions"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Unauthorized",
+                    "code": 401,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                }
+            ],
+            "event": [],
+            "protocolProfileBehavior": {
+                "disableBodyPruning": true
+            }
+        },
+        {
+            "id": "1fe98f0f-ad58-4d77-ab64-29c8dec73305",
+            "name": "List codings",
+            "request": {
+                "name": "List codings",
+                "description": {
+                    "content": "Returns medical coding history entries for the study.\nFilter attributes: ``siteId``, ``subjectId``, ``formId``, ``recordId``,\n``revision``, ``variable``, ``value``, ``code``, ``codedBy``, ``reason``,\n``dictionaryName``, ``dictionaryVersion`` and ``dateCoded``.\n",
+                    "type": "text/plain"
+                },
+                "url": {
+                    "path": [
+                        "studies",
+                        ":studyKey",
+                        "codings"
+                    ],
+                    "host": [
+                        "{{baseUrl}}"
+                    ],
+                    "query": [
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "page",
+                            "value": "0"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "size",
+                            "value": "25"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "sort",
+                            "value": "<string>"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                "type": "text/plain"
+                            },
+                            "key": "filter",
+                            "value": "<string>"
+                        }
+                    ],
+                    "variable": [
+                        {
+                            "type": "any",
+                            "value": "<string>",
+                            "key": "studyKey",
+                            "disabled": false,
+                            "description": {
+                                "content": "(Required) ",
+                                "type": "text/plain"
+                            }
+                        }
+                    ]
+                },
+                "header": [
+                    {
+                        "key": "Accept",
+                        "value": "application/json"
+                    }
+                ],
+                "method": "GET",
+                "body": {},
+                "auth": null
+            },
+            "response": [
+                {
+                    "id": "437bcfa3-f606-4a53-87d7-c3711ccdaee6",
+                    "name": "Coding list",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "codings"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "OK",
+                    "code": 200,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"siteName\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectKey\": \"<string>\",\n      \"formId\": \"<integer>\",\n      \"formName\": \"<string>\",\n      \"formKey\": \"<string>\",\n      \"recordId\": \"<integer>\",\n      \"variable\": \"<string>\",\n      \"value\": \"<string>\",\n      \"codingId\": \"<integer>\",\n      \"code\": \"<string>\",\n      \"codedBy\": \"<string>\",\n      \"dictionaryName\": \"<string>\",\n      \"dictionaryVersion\": \"<string>\",\n      \"dateCoded\": \"<string>\"\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"siteName\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectKey\": \"<string>\",\n      \"formId\": \"<integer>\",\n      \"formName\": \"<string>\",\n      \"formKey\": \"<string>\",\n      \"recordId\": \"<integer>\",\n      \"variable\": \"<string>\",\n      \"value\": \"<string>\",\n      \"codingId\": \"<integer>\",\n      \"code\": \"<string>\",\n      \"codedBy\": \"<string>\",\n      \"dictionaryName\": \"<string>\",\n      \"dictionaryVersion\": \"<string>\",\n      \"dateCoded\": \"<string>\"\n    }\n  ]\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "7b8008ba-04df-406b-90a5-b9124ed43cb9",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "codings"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Bad Request",
+                    "code": 400,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "e19ec3d3-fb84-4395-941c-5a5269917f66",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "codings"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Unauthorized",
+                    "code": 401,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                }
+            ],
+            "event": [],
+            "protocolProfileBehavior": {
+                "disableBodyPruning": true
+            }
+        },
+        {
+            "id": "166bd2d1-e95f-4130-8755-eb091206beab",
+            "name": "List queries",
+            "request": {
+                "name": "List queries",
+                "description": {
+                    "content": "Returns queries associated with the study.",
+                    "type": "text/plain"
+                },
+                "url": {
+                    "path": [
+                        "studies",
+                        ":studyKey",
+                        "queries"
+                    ],
+                    "host": [
+                        "{{baseUrl}}"
+                    ],
+                    "query": [
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "page",
+                            "value": "0"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "size",
+                            "value": "25"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "sort",
+                            "value": "<string>"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                "type": "text/plain"
+                            },
+                            "key": "filter",
+                            "value": "<string>"
+                        }
+                    ],
+                    "variable": [
+                        {
+                            "type": "any",
+                            "value": "<string>",
+                            "key": "studyKey",
+                            "disabled": false,
+                            "description": {
+                                "content": "(Required) ",
+                                "type": "text/plain"
+                            }
+                        }
+                    ]
+                },
+                "header": [
+                    {
+                        "key": "Accept",
+                        "value": "application/json"
+                    }
+                ],
+                "method": "GET",
+                "body": {},
+                "auth": null
+            },
+            "response": [
+                {
+                    "id": "b92945a2-d99c-44d3-a4dd-143c402ee392",
+                    "name": "Query list",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "queries"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "OK",
+                    "code": 200,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"annotationId\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"recordId\": \"<integer>\",\n      \"variable\": \"<string>\",\n      \"subjectKey\": \"<string>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"annotationId\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"recordId\": \"<integer>\",\n      \"variable\": \"<string>\",\n      \"subjectKey\": \"<string>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    }\n  ]\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "d11ef145-2339-4743-96a8-0afa33722323",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "queries"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Bad Request",
+                    "code": 400,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "44dda5f8-638d-42db-a1f9-debe6905e65b",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "queries"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Unauthorized",
+                    "code": 401,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                }
+            ],
+            "event": [],
+            "protocolProfileBehavior": {
+                "disableBodyPruning": true
+            }
+        },
+        {
+            "id": "c89a8ded-8009-4404-9c89-5bb7dcc65694",
+            "name": "List visits",
+            "request": {
+                "name": "List visits",
+                "description": {
+                    "content": "Returns visit data for subjects in the study.\nFilter attributes: ``intervalId``, ``intervalName``, ``intervalGroupId``,\n``intervalGroupName``, ``startDate``, ``endDate``, ``dueDate``,\n``visitDate``, ``dateCreated`` and ``dateModified``.\n",
+                    "type": "text/plain"
+                },
+                "url": {
+                    "path": [
+                        "studies",
+                        ":studyKey",
+                        "visits"
+                    ],
+                    "host": [
+                        "{{baseUrl}}"
+                    ],
+                    "query": [
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "page",
+                            "value": "0"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "size",
+                            "value": "25"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "sort",
+                            "value": "<string>"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                "type": "text/plain"
+                            },
+                            "key": "filter",
+                            "value": "<string>"
+                        }
+                    ],
+                    "variable": [
+                        {
+                            "type": "any",
+                            "value": "<string>",
+                            "key": "studyKey",
+                            "disabled": false,
+                            "description": {
+                                "content": "(Required) ",
+                                "type": "text/plain"
+                            }
+                        }
+                    ]
+                },
+                "header": [
+                    {
+                        "key": "Accept",
+                        "value": "application/json"
+                    }
+                ],
+                "method": "GET",
+                "body": {},
+                "auth": null
+            },
+            "response": [
+                {
+                    "id": "8a404a5b-6b69-40dc-9d21-2c4a6944decd",
+                    "name": "Visit list",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "visits"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "OK",
+                    "code": 200,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"visitId\": \"<integer>\",\n      \"studyKey\": \"<string>\",\n      \"intervalId\": \"<integer>\",\n      \"intervalName\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectKey\": \"<string>\",\n      \"startDate\": \"<string>\",\n      \"endDate\": \"<string>\",\n      \"dueDate\": \"<string>\",\n      \"visitDate\": \"<string>\",\n      \"deleted\": \"<boolean>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    },\n    {\n      \"visitId\": \"<integer>\",\n      \"studyKey\": \"<string>\",\n      \"intervalId\": \"<integer>\",\n      \"intervalName\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectKey\": \"<string>\",\n      \"startDate\": \"<string>\",\n      \"endDate\": \"<string>\",\n      \"dueDate\": \"<string>\",\n      \"visitDate\": \"<string>\",\n      \"deleted\": \"<boolean>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    }\n  ]\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "1239db17-036b-45aa-9fb6-e720086ce311",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "visits"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Bad Request",
+                    "code": 400,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "142cadf4-de36-44f3-82aa-5abaa084a409",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "visits"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Unauthorized",
+                    "code": 401,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                }
+            ],
+            "event": [],
+            "protocolProfileBehavior": {
+                "disableBodyPruning": true
+            }
+        },
+        {
+            "id": "0c7eacb1-6fc6-4a45-b1b0-e652c7a8bd34",
+            "name": "List users",
+            "request": {
+                "name": "List users",
+                "description": {
+                    "content": "Returns users associated with the study.",
+                    "type": "text/plain"
+                },
+                "url": {
+                    "path": [
+                        "studies",
+                        ":studyKey",
+                        "users"
+                    ],
+                    "host": [
+                        "{{baseUrl}}"
+                    ],
+                    "query": [
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "page",
+                            "value": "0"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "size",
+                            "value": "25"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "sort",
+                            "value": "<string>"
+                        },
+                        {
+                            "disabled": false,
+                            "description": {
+                                "content": "",
+                                "type": "text/plain"
+                            },
+                            "key": "includeInactive",
+                            "value": "false"
+                        }
+                    ],
+                    "variable": [
+                        {
+                            "type": "any",
+                            "value": "<string>",
+                            "key": "studyKey",
+                            "disabled": false,
+                            "description": {
+                                "content": "(Required) ",
+                                "type": "text/plain"
+                            }
+                        }
+                    ]
+                },
+                "header": [
+                    {
+                        "key": "Accept",
+                        "value": "application/json"
+                    }
+                ],
+                "method": "GET",
+                "body": {},
+                "auth": null
+            },
+            "response": [
+                {
+                    "id": "62e05ece-d26e-49c5-a18f-f4be08f0f1da",
+                    "name": "User list",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "users"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "includeInactive",
+                                    "value": "false"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "OK",
+                    "code": 200,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"userId\": \"<string>\",\n      \"login\": \"<string>\",\n      \"firstName\": \"<string>\",\n      \"lastName\": \"<string>\",\n      \"email\": \"<string>\",\n      \"userActiveInStudy\": \"<boolean>\"\n    },\n    {\n      \"userId\": \"<string>\",\n      \"login\": \"<string>\",\n      \"firstName\": \"<string>\",\n      \"lastName\": \"<string>\",\n      \"email\": \"<string>\",\n      \"userActiveInStudy\": \"<boolean>\"\n    }\n  ]\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "30378725-9642-4688-870b-6d4792096e48",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "users"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "includeInactive",
+                                    "value": "false"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Bad Request",
+                    "code": 400,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "86113903-da23-48e5-a14b-31d5ec814852",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "users"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "includeInactive",
+                                    "value": "false"
+                                }
+                            ],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Unauthorized",
+                    "code": 401,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                }
+            ],
+            "event": [],
+            "protocolProfileBehavior": {
+                "disableBodyPruning": true
+            }
+        },
+        {
+            "id": "ca53b1f3-7e69-4b64-8811-d72483733b0c",
+            "name": "Retrieve job status",
+            "request": {
+                "name": "Retrieve job status",
+                "description": {
+                    "content": "Checks the status of a record import job.",
+                    "type": "text/plain"
+                },
+                "url": {
+                    "path": [
+                        "studies",
+                        ":studyKey",
+                        "jobs",
+                        ":batchId"
+                    ],
+                    "host": [
+                        "{{baseUrl}}"
+                    ],
+                    "query": [],
+                    "variable": [
+                        {
+                            "type": "any",
+                            "value": "<string>",
+                            "key": "studyKey",
+                            "disabled": false,
+                            "description": {
+                                "content": "(Required) ",
+                                "type": "text/plain"
+                            }
+                        },
+                        {
+                            "type": "any",
+                            "value": "<string>",
+                            "key": "batchId",
+                            "disabled": false,
+                            "description": {
+                                "content": "(Required) ",
+                                "type": "text/plain"
+                            }
+                        }
+                    ]
+                },
+                "header": [
+                    {
+                        "key": "Accept",
+                        "value": "application/json"
+                    }
+                ],
+                "method": "GET",
+                "body": {},
+                "auth": null
+            },
+            "response": [
+                {
+                    "id": "afed929a-b546-4ab3-920d-22801247b7da",
+                    "name": "Job status",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "jobs",
+                                ":batchId"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "OK",
+                    "code": 200,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"jobId\": \"<string>\",\n  \"batchId\": \"<string>\",\n  \"state\": \"<string>\",\n  \"dateCreated\": \"<string>\",\n  \"dateStarted\": \"<string>\",\n  \"dateFinished\": \"<string>\",\n  \"progress\": \"<integer>\",\n  \"resultUrl\": \"<string>\"\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "60508af7-bf4f-4ee9-8b68-2e167c38dd52",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "jobs",
+                                ":batchId"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Bad Request",
+                    "code": 400,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                },
+                {
+                    "id": "e80d43e2-77d9-449e-b857-999ae6f89cca",
+                    "name": "Error information when the request fails",
+                    "originalRequest": {
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "jobs",
+                                ":batchId"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": []
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            },
+                            {
+                                "description": {
+                                    "content": "Added as a part of security scheme: apikey",
+                                    "type": "text/plain"
+                                },
+                                "key": "x-api-key",
+                                "value": "<API Key>"
+                            }
+                        ],
+                        "method": "GET",
+                        "body": {}
+                    },
+                    "status": "Unauthorized",
+                    "code": 401,
+                    "header": [
+                        {
+                            "key": "Content-Type",
+                            "value": "application/json"
+                        }
+                    ],
+                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                    "cookie": [],
+                    "_postman_previewlanguage": "json"
+                }
+            ],
+            "event": [],
+            "protocolProfileBehavior": {
+                "disableBodyPruning": true
+            }
+        }
+    ],
+    "auth": {
+        "type": "apikey",
+        "apikey": [
+            {
+                "type": "any",
+                "value": "x-api-key",
+                "key": "key"
+            },
+            {
+                "type": "any",
+                "value": "{{apiKey}}",
+                "key": "value"
+            },
+            {
+                "type": "any",
+                "value": "header",
+                "key": "in"
+            }
+        ]
+    },
+    "event": [],
+    "variable": [
+        {
+            "key": "baseUrl",
+            "value": "https://edc.prod.imednetapi.com/api/v1/edc"
+        }
+    ],
+    "info": {
+        "_postman_id": "eabc648d-77c0-4d76-a7a6-9d7fc4bf0670",
+        "name": "iMednet EDC API",
+        "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+        "description": {
+            "content": "Swagger specification for the iMednet EDC REST API derived from\nthe SDK documentation. The API exposes clinical study resources\nvia JSON. Requests require `x-api-key` and `x-imn-security-key`\nheaders for authentication. API keys should remain private.\nExample request using ``curl``::\n\n  curl -X GET https://edc.prod.imednetapi.com/api/v1/edc/studies/STUDYKEY/sites \\\n    -H 'x-api-key: XXXXXXXX' \\\n    -H 'x-imn-security-key: XXX-XXX-XX-XXXXXX' \\\n    -H 'Content-Type: application/json'\n\nResults may be filtered using query parameters. A ``filter`` string\naccepts attribute/operator/value pairs such as ``formId>10`` and\n``formType==SUBJECT`` combined with ``and``/``;`` or ``or``/``,``, while\n``recordDataFilter`` applies to dynamic question data. Supported\noperators include ``<``, ``<=``, ``>``, ``>=``, ``==`` and ``!=``. Dates\nuse UTC timestamps like ``YYYY-MM-DDTHH:MM:SSZ``.\n",
+            "type": "text/plain"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- update the iMednet Postman workflow so it keeps the generated collection in the repo instead of posting to Postman
- document the new collection location in the README

## Testing
- `npm view openapi-to-postmanv2 version`


------
https://chatgpt.com/codex/tasks/task_e_686eb0dde350832caeb15ed5c3d42b99