### PR TITLE
Staging

### DIFF
--- a/.github/workflows/openapi-imednet.yml
+++ b/.github/workflows/openapi-imednet.yml
@@ -18,20 +18,20 @@ jobs:
   generate-imednet:
     needs: validate-imednet
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        language: [c, csharp, dart, go, java, javascript, python, r, ruby, rust]
     steps:
       - uses: actions/checkout@v3
-      - name: Generate ${{ matrix.language }} client for iMednet
+      - name: Generate client SDKs
         run: |
-          mkdir -p imednet/${{ matrix.language }}
-          docker run --rm -u $(id -u):$(id -g) -v ${{ github.workspace }}:/local \
-            openapitools/openapi-generator-cli generate \
-            -i /local/imednet/openapi.yaml \
-            -g ${{ matrix.language }} \
-            -o /local/imednet/${{ matrix.language }}
-      - uses: actions/upload-artifact@v4
+          languages="c csharp dart go java javascript python r ruby rust"
+          for lang in $languages; do
+            mkdir -p imednet/$lang
+            docker run --rm -u $(id -u):$(id -g) -v ${{ github.workspace }}:/local \
+              openapitools/openapi-generator-cli generate \
+              -i /local/imednet/openapi.yaml \
+              -g $lang \
+              -o /local/imednet/$lang
+          done
+      - uses: EndBug/add-and-commit@v9
         with:
-          name: imednet-${{ matrix.language }}
-          path: imednet/${{ matrix.language }}
+          add: imednet/*
+          message: Update generated iMednet SDKs


### PR DESCRIPTION
This pull request simplifies the workflow for generating client SDKs in the `generate-imednet` job of the `.github/workflows/openapi-imednet.yml` file. The changes replace the matrix strategy with a loop-based approach and update the artifact handling process.

### Workflow simplification:

* Removed the `strategy.matrix` configuration for generating SDKs for multiple languages and replaced it with a shell loop, reducing complexity in the workflow. The languages are now defined as a space-separated string and iterated over in the loop. (`[.github/workflows/openapi-imednet.ymlL21-R37](diffhunk://#diff-9242373eee7c715472c5f9094d082da5bc2a75e6973cbc1670925cc9c288c2ecL21-R37)`)

### Artifact handling update:

* Replaced the `actions/upload-artifact` step with `EndBug/add-and-commit`. Instead of uploading individual artifacts for each language, the workflow now adds all generated SDKs to the repository and commits them with a standardized message. (`[.github/workflows/openapi-imednet.ymlL21-R37](diffhunk://#diff-9242373eee7c715472c5f9094d082da5bc2a75e6973cbc1670925cc9c288c2ecL21-R37)`)