### PR TITLE
Refactor iMednet spec

### DIFF
--- a/imednet/openapi.yaml
+++ b/imednet/openapi.yaml
@@ -5,26 +5,77 @@ info:
   description: |
     Swagger specification for the iMednet EDC REST API derived from
     the SDK documentation. The API exposes clinical study resources
-    via JSON. Requests require `x-api-key` and `x-imn-security-key`
-    headers for authentication. API keys should remain private.
-    Example request using ``curl``::
+    via JSON.
+
+    **Security and Validation**
+
+    API keys should remain secure. Mednet does not recommend sharing
+    keys or making them public. Publicly exposing your credentials can
+    result in your account being compromised. Some implementation
+    decisions can expose keys and should be avoided wherever possible
+    (e.g. CORS).
+
+    Making a successful request requires authentication using request
+    headers. Valid values for the `x-api-key` and `x-imn-security-key`
+    header attributes are required to ensure secure access to your
+    data. The content of your header might look something like the
+    following::
+
+      {
+          "x-api-key": "your-imednet-supplied-api-key",
+          "x-imn-security-key": "your-imednet-supplied-security-key"
+      }
+
+    Example request using ``curl`` to request sites from STUDYKEY::
 
       curl -X GET https://edc.prod.imednetapi.com/api/v1/edc/studies/STUDYKEY/sites \
         -H 'x-api-key: XXXXXXXX' \
         -H 'x-imn-security-key: XXX-XXX-XX-XXXXXX' \
         -H 'Content-Type: application/json'
-    
+
     Results may be filtered using query parameters. A ``filter`` string
     accepts attribute/operator/value pairs such as ``formId>10`` and
     ``formType==SUBJECT`` combined with ``and``/``;`` or ``or``/``,``, while
     ``recordDataFilter`` applies to dynamic question data. Supported
     operators include ``<``, ``<=``, ``>``, ``>=``, ``==`` and ``!=``. Dates
     use UTC timestamps like ``YYYY-MM-DDTHH:MM:SSZ``.
+    Error responses use standard HTTP status codes to convey the reason for failure:
+      - **400 Bad Request** for invalid input parameters
+      - **401 Unauthorized** when authentication headers are missing or invalid
+      - **403 Forbidden** when the study key is invalid or access is denied
+      - **404 Not Found** when the resource does not exist
+      - **429 Too Many Requests** when request limits are exceeded
+      - **500 Internal Server Error** for unexpected failures
+
 servers:
   - url: https://edc.prod.imednetapi.com/api/v1/edc
-security:
-  - ApiKey: []
-    ImnSecurityKey: []
+tags:
+  - name: Studies
+    description: Study metadata
+  - name: Forms
+    description: eCRF form definitions
+  - name: Variables
+    description: eCRF field variables
+  - name: Intervals
+    description: Scheduled visits or intervals
+  - name: Sites
+    description: Study sites
+  - name: Subjects
+    description: Enrolled subjects
+  - name: Records
+    description: eCRF record instances
+  - name: RecordRevisions
+    description: Change history for records
+  - name: Codings
+    description: Medical coding history
+  - name: Queries
+    description: Data queries
+  - name: Visits
+    description: Subject visits
+  - name: Users
+    description: Study users
+  - name: Jobs
+    description: Background jobs
 paths:
   /studies:
     get:
@@ -34,6 +85,8 @@ paths:
         Filter attributes: ``studyKey``, ``studyType``, ``studyName``,
         ``dateCreated`` and ``dateModified``.
       operationId: listStudies
+      tags:
+        - Studies
       parameters:
         - in: query
           name: page
@@ -63,14 +116,24 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedStudyList'
         '400':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/BadRequest'
         '401':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/Unauthorized'
+        '403':
+            $ref: '#/components/responses/Forbidden'
+        '404':
+            $ref: '#/components/responses/NotFound'
+        '429':
+            $ref: '#/components/responses/TooManyRequests'
+        '500':
+            $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}:
     get:
       summary: Retrieve a study
       description: Return metadata for the specified study.
       operationId: getStudy
+      tags:
+        - Studies
       parameters:
         - in: path
           name: studyKey
@@ -85,9 +148,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/Study'
         '400':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/BadRequest'
         '401':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/Unauthorized'
+        '403':
+            $ref: '#/components/responses/Forbidden'
+        '404':
+            $ref: '#/components/responses/NotFound'
+        '429':
+            $ref: '#/components/responses/TooManyRequests'
+        '500':
+            $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}/forms:
     get:
       summary: List forms
@@ -96,6 +167,8 @@ paths:
         Filter attributes: ``formId``, ``formKey``, ``formName``,
         ``formType``, ``dateCreated`` and ``dateModified``.
       operationId: listForms
+      tags:
+        - Forms
       parameters:
         - $ref: '#/components/parameters/studyKey'
         - $ref: '#/components/parameters/pageParam'
@@ -110,9 +183,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedFormList'
         '400':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/BadRequest'
         '401':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/Unauthorized'
+        '403':
+            $ref: '#/components/responses/Forbidden'
+        '404':
+            $ref: '#/components/responses/NotFound'
+        '429':
+            $ref: '#/components/responses/TooManyRequests'
+        '500':
+            $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}/variables:
     get:
       summary: List variables
@@ -122,6 +203,8 @@ paths:
         ``dateCreated``, ``dateModified``, ``formId``, ``formKey``,
         ``formName`` and ``label``.
       operationId: listVariables
+      tags:
+        - Variables
       parameters:
         - $ref: '#/components/parameters/studyKey'
         - $ref: '#/components/parameters/pageParam'
@@ -136,9 +219,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedVariableList'
         '400':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/BadRequest'
         '401':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/Unauthorized'
+        '403':
+            $ref: '#/components/responses/Forbidden'
+        '404':
+            $ref: '#/components/responses/NotFound'
+        '429':
+            $ref: '#/components/responses/TooManyRequests'
+        '500':
+            $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}/intervals:
     get:
       summary: List intervals
@@ -147,6 +238,8 @@ paths:
         Filter attributes: ``intervalId``, ``intervalName``, ``intervalGroupId``,
         ``intervalGroupName``, ``dateCreated`` and ``dateModified``.
       operationId: listIntervals
+      tags:
+        - Intervals
       parameters:
         - $ref: '#/components/parameters/studyKey'
         - $ref: '#/components/parameters/pageParam'
@@ -161,9 +254,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedIntervalList'
         '400':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/BadRequest'
         '401':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/Unauthorized'
+        '403':
+            $ref: '#/components/responses/Forbidden'
+        '404':
+            $ref: '#/components/responses/NotFound'
+        '429':
+            $ref: '#/components/responses/TooManyRequests'
+        '500':
+            $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}/sites:
     get:
       summary: List sites
@@ -172,6 +273,8 @@ paths:
         Filter attributes: ``siteId``, ``siteName``, ``siteEnrollmentStatus``,
         ``dateCreated`` and ``dateModified``.
       operationId: listSites
+      tags:
+        - Sites
       parameters:
         - $ref: '#/components/parameters/studyKey'
         - $ref: '#/components/parameters/pageParam'
@@ -186,14 +289,24 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedSiteList'
         '400':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/BadRequest'
         '401':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/Unauthorized'
+        '403':
+            $ref: '#/components/responses/Forbidden'
+        '404':
+            $ref: '#/components/responses/NotFound'
+        '429':
+            $ref: '#/components/responses/TooManyRequests'
+        '500':
+            $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}/subjects:
     get:
       summary: List subjects
       description: Returns all subjects enrolled in the study.
       operationId: listSubjects
+      tags:
+        - Subjects
       parameters:
         - $ref: '#/components/parameters/studyKey'
         - $ref: '#/components/parameters/pageParam'
@@ -208,9 +321,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedSubjectList'
         '400':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/BadRequest'
         '401':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/Unauthorized'
+        '403':
+            $ref: '#/components/responses/Forbidden'
+        '404':
+            $ref: '#/components/responses/NotFound'
+        '429':
+            $ref: '#/components/responses/TooManyRequests'
+        '500':
+            $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}/records:
     get:
       summary: List records
@@ -220,6 +341,8 @@ paths:
         ``recordId``, ``parentRecordId``, ``recordType``, ``recordStatus``,
         ``subjectKey``, ``dateCreated`` and ``dateModified``.
       operationId: listRecords
+      tags:
+        - Records
       parameters:
         - $ref: '#/components/parameters/studyKey'
         - $ref: '#/components/parameters/pageParam'
@@ -244,13 +367,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedRecordList'
         '400':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/BadRequest'
         '401':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/Unauthorized'
+        '403':
+            $ref: '#/components/responses/Forbidden'
+        '404':
+            $ref: '#/components/responses/NotFound'
+        '429':
+            $ref: '#/components/responses/TooManyRequests'
+        '500':
+            $ref: '#/components/responses/InternalServerError'
     post:
       summary: Create records
       description: Adds new records and returns a job for asynchronous processing.
       operationId: createRecords
+      tags:
+        - Records
       parameters:
         - $ref: '#/components/parameters/studyKey'
       requestBody:
@@ -305,9 +438,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/JobResponse'
         '400':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/BadRequest'
         '401':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/Unauthorized'
+        '403':
+            $ref: '#/components/responses/Forbidden'
+        '404':
+            $ref: '#/components/responses/NotFound'
+        '429':
+            $ref: '#/components/responses/TooManyRequests'
+        '500':
+            $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}/recordRevisions:
     get:
       summary: List record revisions
@@ -317,6 +458,8 @@ paths:
         ``recordRevision``, ``dataRevision``, ``recordStatus``, ``user``,
         ``reasonForChange`` and ``dateCreated``.
       operationId: listRecordRevisions
+      tags:
+        - RecordRevisions
       parameters:
         - $ref: '#/components/parameters/studyKey'
         - $ref: '#/components/parameters/pageParam'
@@ -331,9 +474,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedRecordRevisionList'
         '400':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/BadRequest'
         '401':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/Unauthorized'
+        '403':
+            $ref: '#/components/responses/Forbidden'
+        '404':
+            $ref: '#/components/responses/NotFound'
+        '429':
+            $ref: '#/components/responses/TooManyRequests'
+        '500':
+            $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}/codings:
     get:
       summary: List codings
@@ -343,6 +494,8 @@ paths:
         ``revision``, ``variable``, ``value``, ``code``, ``codedBy``, ``reason``,
         ``dictionaryName``, ``dictionaryVersion`` and ``dateCoded``.
       operationId: listCodings
+      tags:
+        - Codings
       parameters:
         - $ref: '#/components/parameters/studyKey'
         - $ref: '#/components/parameters/pageParam'
@@ -357,14 +510,24 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedCodingList'
         '400':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/BadRequest'
         '401':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/Unauthorized'
+        '403':
+            $ref: '#/components/responses/Forbidden'
+        '404':
+            $ref: '#/components/responses/NotFound'
+        '429':
+            $ref: '#/components/responses/TooManyRequests'
+        '500':
+            $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}/queries:
     get:
       summary: List queries
       description: Returns queries associated with the study.
       operationId: listQueries
+      tags:
+        - Queries
       parameters:
         - $ref: '#/components/parameters/studyKey'
         - $ref: '#/components/parameters/pageParam'
@@ -379,9 +542,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedQueryList'
         '400':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/BadRequest'
         '401':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/Unauthorized'
+        '403':
+            $ref: '#/components/responses/Forbidden'
+        '404':
+            $ref: '#/components/responses/NotFound'
+        '429':
+            $ref: '#/components/responses/TooManyRequests'
+        '500':
+            $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}/visits:
     get:
       summary: List visits
@@ -391,6 +562,8 @@ paths:
         ``intervalGroupName``, ``startDate``, ``endDate``, ``dueDate``,
         ``visitDate``, ``dateCreated`` and ``dateModified``.
       operationId: listVisits
+      tags:
+        - Visits
       parameters:
         - $ref: '#/components/parameters/studyKey'
         - $ref: '#/components/parameters/pageParam'
@@ -405,14 +578,24 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedVisitList'
         '400':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/BadRequest'
         '401':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/Unauthorized'
+        '403':
+            $ref: '#/components/responses/Forbidden'
+        '404':
+            $ref: '#/components/responses/NotFound'
+        '429':
+            $ref: '#/components/responses/TooManyRequests'
+        '500':
+            $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}/users:
     get:
       summary: List users
       description: Returns users associated with the study.
       operationId: listUsers
+      tags:
+        - Users
       parameters:
         - $ref: '#/components/parameters/studyKey'
         - $ref: '#/components/parameters/pageParam'
@@ -431,14 +614,24 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedUserList'
         '400':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/BadRequest'
         '401':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/Unauthorized'
+        '403':
+            $ref: '#/components/responses/Forbidden'
+        '404':
+            $ref: '#/components/responses/NotFound'
+        '429':
+            $ref: '#/components/responses/TooManyRequests'
+        '500':
+            $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}/jobs/{batchId}:
     get:
       summary: Retrieve job status
       description: Checks the status of a record import job.
       operationId: getJob
+      tags:
+        - Jobs
       parameters:
         - $ref: '#/components/parameters/studyKey'
         - in: path
@@ -454,19 +647,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/JobStatus'
         '400':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/BadRequest'
         '401':
-          $ref: '#/components/responses/ErrorResponse'
+            $ref: '#/components/responses/Unauthorized'
+        '403':
+            $ref: '#/components/responses/Forbidden'
+        '404':
+            $ref: '#/components/responses/NotFound'
+        '429':
+            $ref: '#/components/responses/TooManyRequests'
+        '500':
+            $ref: '#/components/responses/InternalServerError'
 components:
-  securitySchemes:
-    ApiKey:
-      type: apiKey
-      in: header
-      name: x-api-key
-    ImnSecurityKey:
-      type: apiKey
-      in: header
-      name: x-imn-security-key
   parameters:
     studyKey:
       in: path
@@ -508,6 +700,60 @@ components:
   responses:
     ErrorResponse:
       description: Error information when the request fails
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              metadata:
+                $ref: '#/components/schemas/Metadata'
+    BadRequest:
+      description: The request was malformed. The response body will include an error providing further information
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              metadata:
+                $ref: '#/components/schemas/Metadata'
+    Unauthorized:
+      description: The request was rejected related to security issue. The response body will include an error providing further information
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              metadata:
+                $ref: '#/components/schemas/Metadata'
+    Forbidden:
+      description: The request was rejected related to security issue, likely an invalid studyKey. The response body will include an error providing further information
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              metadata:
+                $ref: '#/components/schemas/Metadata'
+    NotFound:
+      description: The request was rejected related to invalid resource issue. The response body will include an error providing further information
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              metadata:
+                $ref: '#/components/schemas/Metadata'
+    TooManyRequests:
+      description: The request was rejected related to limit-exceeding requests. Please contact Mednet support for assistance
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              metadata:
+                $ref: '#/components/schemas/Metadata'
+    InternalServerError:
+      description: The request was rejected because of unknown issue. Please contact Mednet support for assistance
       content:
         application/json:
           schema:

--- a/imednet/postman/collection.json
+++ b/imednet/postman/collection.json
@@ -1,76 +1,18 @@
 {
     "item": [
         {
-            "id": "7f4429d2-0315-4d13-b695-cafb6f01eb94",
-            "name": "List studies",
-            "request": {
-                "name": "List studies",
-                "description": {
-                    "content": "Returns metadata for studies the API key can access.\nFilter attributes: ``studyKey``, ``studyType``, ``studyName``,\n``dateCreated`` and ``dateModified``.\n",
-                    "type": "text/plain"
-                },
-                "url": {
-                    "path": [
-                        "studies"
-                    ],
-                    "host": [
-                        "{{baseUrl}}"
-                    ],
-                    "query": [
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "page",
-                            "value": "0"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "size",
-                            "value": "25"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "sort",
-                            "value": "studyKey,asc"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "filter",
-                            "value": "<string>"
-                        }
-                    ],
-                    "variable": []
-                },
-                "header": [
-                    {
-                        "key": "Accept",
-                        "value": "application/json"
-                    }
-                ],
-                "method": "GET",
-                "body": {},
-                "auth": null
-            },
-            "response": [
+            "name": "Studies",
+            "description": "Study metadata",
+            "item": [
                 {
-                    "id": "01304a11-6682-4aae-b923-3ec75f01578d",
-                    "name": "List of studies",
-                    "originalRequest": {
+                    "id": "0dfcf9f9-56a0-454d-ac1c-812a2956c74c",
+                    "name": "List studies",
+                    "request": {
+                        "name": "List studies",
+                        "description": {
+                            "content": "Returns metadata for studies the API key can access.\nFilter attributes: ``studyKey``, ``studyType``, ``studyName``,\n``dateCreated`` and ``dateModified``.\n",
+                            "type": "text/plain"
+                        },
                         "url": {
                             "path": [
                                 "studies"
@@ -122,461 +64,838 @@
                             {
                                 "key": "Accept",
                                 "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
                             }
                         ],
                         "method": "GET",
-                        "body": {}
+                        "body": {},
+                        "auth": null
                     },
-                    "status": "OK",
-                    "code": 200,
-                    "header": [
+                    "response": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"sponsorKey\": \"<string>\",\n      \"studyKey\": \"<string>\",\n      \"studyId\": \"<integer>\",\n      \"studyName\": \"<string>\",\n      \"studyDescription\": \"<string>\",\n      \"studyType\": \"<string>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    },\n    {\n      \"sponsorKey\": \"<string>\",\n      \"studyKey\": \"<string>\",\n      \"studyId\": \"<integer>\",\n      \"studyName\": \"<string>\",\n      \"studyDescription\": \"<string>\",\n      \"studyType\": \"<string>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    }\n  ]\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "e4a4d00b-b2a2-4135-8e8c-294e07779639",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
+                            "id": "1577595e-2b2b-4327-930a-6bce4070c22a",
+                            "name": "List of studies",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "studyKey,asc"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
                                 },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
                                 {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "studyKey,asc"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "filter",
-                                    "value": "<string>"
+                                    "key": "Content-Type",
+                                    "value": "application/json"
                                 }
                             ],
-                            "variable": []
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"sponsorKey\": \"<string>\",\n      \"studyKey\": \"<string>\",\n      \"studyId\": \"<integer>\",\n      \"studyName\": \"<string>\",\n      \"studyDescription\": \"<string>\",\n      \"studyType\": \"<string>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    },\n    {\n      \"sponsorKey\": \"<string>\",\n      \"studyKey\": \"<string>\",\n      \"studyId\": \"<integer>\",\n      \"studyName\": \"<string>\",\n      \"studyDescription\": \"<string>\",\n      \"studyType\": \"<string>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Bad Request",
-                    "code": 400,
-                    "header": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "88298918-e4b9-447a-9459-7b52b110d89e",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
+                            "id": "c9976dc2-9886-4575-8504-ccbeb8bb163d",
+                            "name": "The request was malformed. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "studyKey,asc"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
                                 },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
                                 {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "studyKey,asc"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "filter",
-                                    "value": "<string>"
+                                    "key": "Content-Type",
+                                    "value": "application/json"
                                 }
                             ],
-                            "variable": []
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "69eee19d-2f49-489f-8989-861413127001",
+                            "name": "The request was rejected related to security issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "studyKey,asc"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "35507c5d-fa41-486c-9179-0875c0d44306",
+                            "name": "The request was rejected related to security issue, likely an invalid studyKey. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "studyKey,asc"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "81aaf244-04f5-4b7c-9f41-9505e37d6548",
+                            "name": "The request was rejected related to invalid resource issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "studyKey,asc"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Not Found",
+                            "code": 404,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "fe22d5b6-22c1-48a5-ac78-bea6446fd278",
+                            "name": "The request was rejected related to limit-exceeding requests. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "studyKey,asc"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "fc80a5a9-323e-466c-9d26-3f935c0ccbff",
+                            "name": "The request was rejected because of unknown issue. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "studyKey,asc"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        }
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
+                },
+                {
+                    "id": "05f6f38e-d264-492b-a492-52243cdb59ff",
+                    "name": "Retrieve a study",
+                    "request": {
+                        "name": "Retrieve a study",
+                        "description": {
+                            "content": "Return metadata for the specified study.",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "value": "<string>",
+                                    "key": "studyKey",
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "(Required) ",
+                                        "type": "text/plain"
+                                    }
+                                }
+                            ]
                         },
                         "header": [
                             {
                                 "key": "Accept",
                                 "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
                             }
                         ],
                         "method": "GET",
-                        "body": {}
+                        "body": {},
+                        "auth": null
                     },
-                    "status": "Unauthorized",
-                    "code": 401,
-                    "header": [
+                    "response": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
+                            "id": "51114d1b-8691-47d4-9b73-4bb971390805",
+                            "name": "Study information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"sponsorKey\": \"<string>\",\n  \"studyKey\": \"<string>\",\n  \"studyId\": \"<integer>\",\n  \"studyName\": \"<string>\",\n  \"studyDescription\": \"<string>\",\n  \"studyType\": \"<string>\",\n  \"dateCreated\": \"<string>\",\n  \"dateModified\": \"<string>\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "6caf9e76-e9ea-4335-9f5b-cb813d765b2e",
+                            "name": "The request was malformed. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "b6309df9-53ac-4d84-8570-3f7f33db2ead",
+                            "name": "The request was rejected related to security issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "f3e81dbd-12b7-4126-a0a8-b2099261653f",
+                            "name": "The request was rejected related to security issue, likely an invalid studyKey. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "535cd34e-2453-4940-bcf1-ee28ef575a29",
+                            "name": "The request was rejected related to invalid resource issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Not Found",
+                            "code": 404,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "1d94350e-a3c2-4766-b8a5-e1c8b33b5750",
+                            "name": "The request was rejected related to limit-exceeding requests. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "3f20c85b-cec9-45c6-aa68-6574cdad7952",
+                            "name": "The request was rejected because of unknown issue. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         }
                     ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
                 }
-            ],
-            "event": [],
-            "protocolProfileBehavior": {
-                "disableBodyPruning": true
-            }
+            ]
         },
         {
-            "id": "1b94311d-a3bd-49c1-a77e-896a8dfdc702",
-            "name": "Retrieve a study",
-            "request": {
-                "name": "Retrieve a study",
-                "description": {
-                    "content": "Return metadata for the specified study.",
-                    "type": "text/plain"
-                },
-                "url": {
-                    "path": [
-                        "studies",
-                        ":studyKey"
-                    ],
-                    "host": [
-                        "{{baseUrl}}"
-                    ],
-                    "query": [],
-                    "variable": [
-                        {
-                            "type": "any",
-                            "value": "<string>",
-                            "key": "studyKey",
-                            "disabled": false,
-                            "description": {
-                                "content": "(Required) ",
-                                "type": "text/plain"
-                            }
-                        }
-                    ]
-                },
-                "header": [
-                    {
-                        "key": "Accept",
-                        "value": "application/json"
-                    }
-                ],
-                "method": "GET",
-                "body": {},
-                "auth": null
-            },
-            "response": [
+            "name": "Forms",
+            "description": "eCRF form definitions",
+            "item": [
                 {
-                    "id": "52e82e0d-f793-42a2-a8f6-9d6abd5bb8d3",
-                    "name": "Study information",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [],
-                            "variable": []
+                    "id": "b97656a0-bd85-4078-9876-0814d3c4ccfc",
+                    "name": "List forms",
+                    "request": {
+                        "name": "List forms",
+                        "description": {
+                            "content": "Returns the design specifications for eCRFs in the study.\nFilter attributes: ``formId``, ``formKey``, ``formName``,\n``formType``, ``dateCreated`` and ``dateModified``.\n",
+                            "type": "text/plain"
                         },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "OK",
-                    "code": 200,
-                    "header": [
-                        {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"sponsorKey\": \"<string>\",\n  \"studyKey\": \"<string>\",\n  \"studyId\": \"<integer>\",\n  \"studyName\": \"<string>\",\n  \"studyDescription\": \"<string>\",\n  \"studyType\": \"<string>\",\n  \"dateCreated\": \"<string>\",\n  \"dateModified\": \"<string>\"\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "a30f451a-f445-4794-913a-709e37620802",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [],
-                            "variable": []
-                        },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Bad Request",
-                    "code": 400,
-                    "header": [
-                        {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "6d9c8068-db49-4017-9c04-69bba75366ad",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [],
-                            "variable": []
-                        },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Unauthorized",
-                    "code": 401,
-                    "header": [
-                        {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                }
-            ],
-            "event": [],
-            "protocolProfileBehavior": {
-                "disableBodyPruning": true
-            }
-        },
-        {
-            "id": "089c7cea-9bf3-4c5c-839f-50d2a22235bf",
-            "name": "List forms",
-            "request": {
-                "name": "List forms",
-                "description": {
-                    "content": "Returns the design specifications for eCRFs in the study.\nFilter attributes: ``formId``, ``formKey``, ``formName``,\n``formType``, ``dateCreated`` and ``dateModified``.\n",
-                    "type": "text/plain"
-                },
-                "url": {
-                    "path": [
-                        "studies",
-                        ":studyKey",
-                        "forms"
-                    ],
-                    "host": [
-                        "{{baseUrl}}"
-                    ],
-                    "query": [
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "page",
-                            "value": "0"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "size",
-                            "value": "25"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "sort",
-                            "value": "<string>"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                "type": "text/plain"
-                            },
-                            "key": "filter",
-                            "value": "<string>"
-                        }
-                    ],
-                    "variable": [
-                        {
-                            "type": "any",
-                            "value": "<string>",
-                            "key": "studyKey",
-                            "disabled": false,
-                            "description": {
-                                "content": "(Required) ",
-                                "type": "text/plain"
-                            }
-                        }
-                    ]
-                },
-                "header": [
-                    {
-                        "key": "Accept",
-                        "value": "application/json"
-                    }
-                ],
-                "method": "GET",
-                "body": {},
-                "auth": null
-            },
-            "response": [
-                {
-                    "id": "e1cf7492-6404-44dc-962f-a87e5c1325fb",
-                    "name": "List of forms",
-                    "originalRequest": {
                         "url": {
                             "path": [
                                 "studies",
@@ -624,291 +943,569 @@
                                     "value": "<string>"
                                 }
                             ],
-                            "variable": []
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "value": "<string>",
+                                    "key": "studyKey",
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "(Required) ",
+                                        "type": "text/plain"
+                                    }
+                                }
+                            ]
                         },
                         "header": [
                             {
                                 "key": "Accept",
                                 "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
                             }
                         ],
                         "method": "GET",
-                        "body": {}
+                        "body": {},
+                        "auth": null
                     },
-                    "status": "OK",
-                    "code": 200,
-                    "header": [
+                    "response": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"formId\": \"<integer>\",\n      \"formKey\": \"<string>\",\n      \"formName\": \"<string>\",\n      \"formType\": \"<string>\",\n      \"revision\": \"<integer>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"formId\": \"<integer>\",\n      \"formKey\": \"<string>\",\n      \"formName\": \"<string>\",\n      \"formType\": \"<string>\",\n      \"revision\": \"<integer>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    }\n  ]\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "876ad83f-823c-442c-bb66-b0ebdbd589cf",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "forms"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
+                            "id": "7938ec36-2cc3-4950-8050-8c825fe11265",
+                            "name": "List of forms",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "forms"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
                                 },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
                                 {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "filter",
-                                    "value": "<string>"
+                                    "key": "Content-Type",
+                                    "value": "application/json"
                                 }
                             ],
-                            "variable": []
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"formId\": \"<integer>\",\n      \"formKey\": \"<string>\",\n      \"formName\": \"<string>\",\n      \"formType\": \"<string>\",\n      \"revision\": \"<integer>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"formId\": \"<integer>\",\n      \"formKey\": \"<string>\",\n      \"formName\": \"<string>\",\n      \"formType\": \"<string>\",\n      \"revision\": \"<integer>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Bad Request",
-                    "code": 400,
-                    "header": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "b701593b-855e-4ccc-8552-91acb889ee2c",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "forms"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
+                            "id": "0d892c9d-d53b-4d06-9fac-0e1e76b2e9e9",
+                            "name": "The request was malformed. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "forms"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
                                 },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
                                 {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "filter",
-                                    "value": "<string>"
+                                    "key": "Content-Type",
+                                    "value": "application/json"
                                 }
                             ],
-                            "variable": []
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Unauthorized",
-                    "code": 401,
-                    "header": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
+                            "id": "4ac1164b-a00a-4fe3-aa39-023f2fadfa37",
+                            "name": "The request was rejected related to security issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "forms"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "e1ba3a4e-86c3-4bbe-b2c0-e92ff1c3d0ec",
+                            "name": "The request was rejected related to security issue, likely an invalid studyKey. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "forms"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "a9aa2f13-a93d-4a0a-8cf3-53df44f7099a",
+                            "name": "The request was rejected related to invalid resource issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "forms"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Not Found",
+                            "code": 404,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "6702c8d3-0cf4-4a54-9eb3-1a0edc87c186",
+                            "name": "The request was rejected related to limit-exceeding requests. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "forms"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "d1073565-404b-4fc2-8430-2ed0cf65f660",
+                            "name": "The request was rejected because of unknown issue. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "forms"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         }
                     ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
                 }
-            ],
-            "event": [],
-            "protocolProfileBehavior": {
-                "disableBodyPruning": true
-            }
+            ]
         },
         {
-            "id": "b4304cc2-f5f3-4af7-a533-6321c73df2dc",
-            "name": "List variables",
-            "request": {
-                "name": "List variables",
-                "description": {
-                    "content": "Retrieves variables representing eCRF fields for the study.\nFilter attributes: ``variableId``, ``variableType``, ``variableName``,\n``dateCreated``, ``dateModified``, ``formId``, ``formKey``,\n``formName`` and ``label``.\n",
-                    "type": "text/plain"
-                },
-                "url": {
-                    "path": [
-                        "studies",
-                        ":studyKey",
-                        "variables"
-                    ],
-                    "host": [
-                        "{{baseUrl}}"
-                    ],
-                    "query": [
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "page",
-                            "value": "0"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "size",
-                            "value": "25"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "sort",
-                            "value": "<string>"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                "type": "text/plain"
-                            },
-                            "key": "filter",
-                            "value": "<string>"
-                        }
-                    ],
-                    "variable": [
-                        {
-                            "type": "any",
-                            "value": "<string>",
-                            "key": "studyKey",
-                            "disabled": false,
-                            "description": {
-                                "content": "(Required) ",
-                                "type": "text/plain"
-                            }
-                        }
-                    ]
-                },
-                "header": [
-                    {
-                        "key": "Accept",
-                        "value": "application/json"
-                    }
-                ],
-                "method": "GET",
-                "body": {},
-                "auth": null
-            },
-            "response": [
+            "name": "Variables",
+            "description": "eCRF field variables",
+            "item": [
                 {
-                    "id": "a9c56b44-38ee-4a23-9adc-8ca85d4a0fb8",
-                    "name": "Variable list",
-                    "originalRequest": {
+                    "id": "308bf352-220c-44ab-a158-de484ad91c72",
+                    "name": "List variables",
+                    "request": {
+                        "name": "List variables",
+                        "description": {
+                            "content": "Retrieves variables representing eCRF fields for the study.\nFilter attributes: ``variableId``, ``variableType``, ``variableName``,\n``dateCreated``, ``dateModified``, ``formId``, ``formKey``,\n``formName`` and ``label``.\n",
+                            "type": "text/plain"
+                        },
                         "url": {
                             "path": [
                                 "studies",
@@ -956,291 +1553,569 @@
                                     "value": "<string>"
                                 }
                             ],
-                            "variable": []
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "value": "<string>",
+                                    "key": "studyKey",
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "(Required) ",
+                                        "type": "text/plain"
+                                    }
+                                }
+                            ]
                         },
                         "header": [
                             {
                                 "key": "Accept",
                                 "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
                             }
                         ],
                         "method": "GET",
-                        "body": {}
+                        "body": {},
+                        "auth": null
                     },
-                    "status": "OK",
-                    "code": 200,
-                    "header": [
+                    "response": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"variableId\": \"<integer>\",\n      \"variableType\": \"<string>\",\n      \"variableName\": \"<string>\",\n      \"sequence\": \"<integer>\",\n      \"revision\": \"<integer>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\",\n      \"formId\": \"<integer>\",\n      \"formKey\": \"<string>\",\n      \"formName\": \"<string>\"\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"variableId\": \"<integer>\",\n      \"variableType\": \"<string>\",\n      \"variableName\": \"<string>\",\n      \"sequence\": \"<integer>\",\n      \"revision\": \"<integer>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\",\n      \"formId\": \"<integer>\",\n      \"formKey\": \"<string>\",\n      \"formName\": \"<string>\"\n    }\n  ]\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "e7b46d6f-5efb-49f0-a301-f3a90fcc9a28",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "variables"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
+                            "id": "23a373be-def3-4a68-b90b-fb6d4ac3c585",
+                            "name": "Variable list",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "variables"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
                                 },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
                                 {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "filter",
-                                    "value": "<string>"
+                                    "key": "Content-Type",
+                                    "value": "application/json"
                                 }
                             ],
-                            "variable": []
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"variableId\": \"<integer>\",\n      \"variableType\": \"<string>\",\n      \"variableName\": \"<string>\",\n      \"sequence\": \"<integer>\",\n      \"revision\": \"<integer>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\",\n      \"formId\": \"<integer>\",\n      \"formKey\": \"<string>\",\n      \"formName\": \"<string>\"\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"variableId\": \"<integer>\",\n      \"variableType\": \"<string>\",\n      \"variableName\": \"<string>\",\n      \"sequence\": \"<integer>\",\n      \"revision\": \"<integer>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\",\n      \"formId\": \"<integer>\",\n      \"formKey\": \"<string>\",\n      \"formName\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Bad Request",
-                    "code": 400,
-                    "header": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "eb8f9852-a703-4755-94d4-e376630c9836",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "variables"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
+                            "id": "6495b83a-736d-4664-bfaa-f5b8adaf0aeb",
+                            "name": "The request was malformed. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "variables"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
                                 },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
                                 {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "filter",
-                                    "value": "<string>"
+                                    "key": "Content-Type",
+                                    "value": "application/json"
                                 }
                             ],
-                            "variable": []
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Unauthorized",
-                    "code": 401,
-                    "header": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
+                            "id": "59b816c5-08be-4738-8714-3c1b95758b06",
+                            "name": "The request was rejected related to security issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "variables"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "47868e00-d45c-4a15-b40e-46b34a19a345",
+                            "name": "The request was rejected related to security issue, likely an invalid studyKey. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "variables"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "d4eb3897-e6d3-485e-9354-c1b30eef0e7a",
+                            "name": "The request was rejected related to invalid resource issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "variables"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Not Found",
+                            "code": 404,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "c2c1ff1a-a922-4622-8e53-e6dcaf012663",
+                            "name": "The request was rejected related to limit-exceeding requests. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "variables"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "4f7ce157-96a3-4372-b369-66f84ff1a680",
+                            "name": "The request was rejected because of unknown issue. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "variables"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         }
                     ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
                 }
-            ],
-            "event": [],
-            "protocolProfileBehavior": {
-                "disableBodyPruning": true
-            }
+            ]
         },
         {
-            "id": "bcd86f22-ebde-4e12-9bcc-da46ee87d464",
-            "name": "List intervals",
-            "request": {
-                "name": "List intervals",
-                "description": {
-                    "content": "Lists scheduled intervals or visits defined for the study.\nFilter attributes: ``intervalId``, ``intervalName``, ``intervalGroupId``,\n``intervalGroupName``, ``dateCreated`` and ``dateModified``.\n",
-                    "type": "text/plain"
-                },
-                "url": {
-                    "path": [
-                        "studies",
-                        ":studyKey",
-                        "intervals"
-                    ],
-                    "host": [
-                        "{{baseUrl}}"
-                    ],
-                    "query": [
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "page",
-                            "value": "0"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "size",
-                            "value": "25"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "sort",
-                            "value": "<string>"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                "type": "text/plain"
-                            },
-                            "key": "filter",
-                            "value": "<string>"
-                        }
-                    ],
-                    "variable": [
-                        {
-                            "type": "any",
-                            "value": "<string>",
-                            "key": "studyKey",
-                            "disabled": false,
-                            "description": {
-                                "content": "(Required) ",
-                                "type": "text/plain"
-                            }
-                        }
-                    ]
-                },
-                "header": [
-                    {
-                        "key": "Accept",
-                        "value": "application/json"
-                    }
-                ],
-                "method": "GET",
-                "body": {},
-                "auth": null
-            },
-            "response": [
+            "name": "Intervals",
+            "description": "Scheduled visits or intervals",
+            "item": [
                 {
-                    "id": "8ae68f6f-e431-440c-b17f-fcada44ea1e2",
-                    "name": "Interval list",
-                    "originalRequest": {
+                    "id": "b1360a2c-ee2a-44ed-8e74-d65845dab705",
+                    "name": "List intervals",
+                    "request": {
+                        "name": "List intervals",
+                        "description": {
+                            "content": "Lists scheduled intervals or visits defined for the study.\nFilter attributes: ``intervalId``, ``intervalName``, ``intervalGroupId``,\n``intervalGroupName``, ``dateCreated`` and ``dateModified``.\n",
+                            "type": "text/plain"
+                        },
                         "url": {
                             "path": [
                                 "studies",
@@ -1288,291 +2163,569 @@
                                     "value": "<string>"
                                 }
                             ],
-                            "variable": []
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "value": "<string>",
+                                    "key": "studyKey",
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "(Required) ",
+                                        "type": "text/plain"
+                                    }
+                                }
+                            ]
                         },
                         "header": [
                             {
                                 "key": "Accept",
                                 "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
                             }
                         ],
                         "method": "GET",
-                        "body": {}
+                        "body": {},
+                        "auth": null
                     },
-                    "status": "OK",
-                    "code": 200,
-                    "header": [
+                    "response": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"intervalId\": \"<integer>\",\n      \"intervalName\": \"<string>\",\n      \"intervalDescription\": \"<string>\",\n      \"intervalSequence\": \"<integer>\",\n      \"intervalGroupId\": \"<integer>\",\n      \"intervalGroupName\": \"<string>\",\n      \"disabled\": \"<boolean>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"intervalId\": \"<integer>\",\n      \"intervalName\": \"<string>\",\n      \"intervalDescription\": \"<string>\",\n      \"intervalSequence\": \"<integer>\",\n      \"intervalGroupId\": \"<integer>\",\n      \"intervalGroupName\": \"<string>\",\n      \"disabled\": \"<boolean>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    }\n  ]\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "93c60bb2-b2c0-4723-8f2c-f8babbf5db85",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "intervals"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
+                            "id": "81bfe1ba-3f76-4ad3-9ff7-9bf79a2bd895",
+                            "name": "Interval list",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "intervals"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
                                 },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
                                 {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "filter",
-                                    "value": "<string>"
+                                    "key": "Content-Type",
+                                    "value": "application/json"
                                 }
                             ],
-                            "variable": []
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"intervalId\": \"<integer>\",\n      \"intervalName\": \"<string>\",\n      \"intervalDescription\": \"<string>\",\n      \"intervalSequence\": \"<integer>\",\n      \"intervalGroupId\": \"<integer>\",\n      \"intervalGroupName\": \"<string>\",\n      \"disabled\": \"<boolean>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"intervalId\": \"<integer>\",\n      \"intervalName\": \"<string>\",\n      \"intervalDescription\": \"<string>\",\n      \"intervalSequence\": \"<integer>\",\n      \"intervalGroupId\": \"<integer>\",\n      \"intervalGroupName\": \"<string>\",\n      \"disabled\": \"<boolean>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Bad Request",
-                    "code": 400,
-                    "header": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "372abbcc-e047-435a-bceb-3997e622ccb7",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "intervals"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
+                            "id": "edaac705-f705-4ee3-8676-d94323b869b6",
+                            "name": "The request was malformed. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "intervals"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
                                 },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
                                 {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "filter",
-                                    "value": "<string>"
+                                    "key": "Content-Type",
+                                    "value": "application/json"
                                 }
                             ],
-                            "variable": []
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Unauthorized",
-                    "code": 401,
-                    "header": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
+                            "id": "5ee2b28e-6213-4b20-a6c0-f56d686b8ed7",
+                            "name": "The request was rejected related to security issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "intervals"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "ed747586-d9ae-450d-91e1-a9eda78ab6c3",
+                            "name": "The request was rejected related to security issue, likely an invalid studyKey. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "intervals"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "6078bace-178a-4c92-8505-438321b2cedf",
+                            "name": "The request was rejected related to invalid resource issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "intervals"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Not Found",
+                            "code": 404,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "bbc7de7d-b101-4922-b7bc-57027cc7c0cc",
+                            "name": "The request was rejected related to limit-exceeding requests. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "intervals"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "901cb06e-e859-467d-8d83-292bcbb42bde",
+                            "name": "The request was rejected because of unknown issue. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "intervals"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         }
                     ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
                 }
-            ],
-            "event": [],
-            "protocolProfileBehavior": {
-                "disableBodyPruning": true
-            }
+            ]
         },
         {
-            "id": "0b7d7ff0-0b8c-4c07-935f-b67f3dfc5bcf",
-            "name": "List sites",
-            "request": {
-                "name": "List sites",
-                "description": {
-                    "content": "Returns the set of sites participating in the study.\nFilter attributes: ``siteId``, ``siteName``, ``siteEnrollmentStatus``,\n``dateCreated`` and ``dateModified``.\n",
-                    "type": "text/plain"
-                },
-                "url": {
-                    "path": [
-                        "studies",
-                        ":studyKey",
-                        "sites"
-                    ],
-                    "host": [
-                        "{{baseUrl}}"
-                    ],
-                    "query": [
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "page",
-                            "value": "0"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "size",
-                            "value": "25"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "sort",
-                            "value": "<string>"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                "type": "text/plain"
-                            },
-                            "key": "filter",
-                            "value": "<string>"
-                        }
-                    ],
-                    "variable": [
-                        {
-                            "type": "any",
-                            "value": "<string>",
-                            "key": "studyKey",
-                            "disabled": false,
-                            "description": {
-                                "content": "(Required) ",
-                                "type": "text/plain"
-                            }
-                        }
-                    ]
-                },
-                "header": [
-                    {
-                        "key": "Accept",
-                        "value": "application/json"
-                    }
-                ],
-                "method": "GET",
-                "body": {},
-                "auth": null
-            },
-            "response": [
+            "name": "Sites",
+            "description": "Study sites",
+            "item": [
                 {
-                    "id": "22b4be64-35fa-4d2d-81a4-6f3094ba82fd",
-                    "name": "Site list",
-                    "originalRequest": {
+                    "id": "0e39211f-95dd-4534-98b8-4d61f8165580",
+                    "name": "List sites",
+                    "request": {
+                        "name": "List sites",
+                        "description": {
+                            "content": "Returns the set of sites participating in the study.\nFilter attributes: ``siteId``, ``siteName``, ``siteEnrollmentStatus``,\n``dateCreated`` and ``dateModified``.\n",
+                            "type": "text/plain"
+                        },
                         "url": {
                             "path": [
                                 "studies",
@@ -1620,632 +2773,1179 @@
                                     "value": "<string>"
                                 }
                             ],
-                            "variable": []
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "value": "<string>",
+                                    "key": "studyKey",
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "(Required) ",
+                                        "type": "text/plain"
+                                    }
+                                }
+                            ]
                         },
                         "header": [
                             {
                                 "key": "Accept",
                                 "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
                             }
                         ],
                         "method": "GET",
-                        "body": {}
+                        "body": {},
+                        "auth": null
                     },
-                    "status": "OK",
-                    "code": 200,
-                    "header": [
+                    "response": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"siteName\": \"<string>\",\n      \"siteEnrollmentStatus\": \"<string>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"siteName\": \"<string>\",\n      \"siteEnrollmentStatus\": \"<string>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    }\n  ]\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "53e58c83-35ee-4996-9222-3cbe0a2a211a",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "sites"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
+                            "id": "995aa333-c2a7-4b6a-aac5-be2244bb2513",
+                            "name": "Site list",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "sites"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
                                 },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
                                 {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "filter",
-                                    "value": "<string>"
+                                    "key": "Content-Type",
+                                    "value": "application/json"
                                 }
                             ],
-                            "variable": []
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"siteName\": \"<string>\",\n      \"siteEnrollmentStatus\": \"<string>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"siteName\": \"<string>\",\n      \"siteEnrollmentStatus\": \"<string>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Bad Request",
-                    "code": 400,
-                    "header": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "d1411593-34ed-4fff-9330-75c038e11590",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "sites"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
+                            "id": "9ff28f3b-a4f5-4687-b2fa-59fc211747ed",
+                            "name": "The request was malformed. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "sites"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
                                 },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
                                 {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "filter",
-                                    "value": "<string>"
+                                    "key": "Content-Type",
+                                    "value": "application/json"
                                 }
                             ],
-                            "variable": []
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Unauthorized",
-                    "code": 401,
-                    "header": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
+                            "id": "8ce1495d-dcb1-49ef-a92c-e3b53999099c",
+                            "name": "The request was rejected related to security issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "sites"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "6e2c451b-a363-47ad-bddf-eb1e30a0ec15",
+                            "name": "The request was rejected related to security issue, likely an invalid studyKey. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "sites"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "3f85f83f-079e-43c5-afa0-5889c160d3fd",
+                            "name": "The request was rejected related to invalid resource issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "sites"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Not Found",
+                            "code": 404,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "7c4f2f74-6076-4363-ad13-3a1de255c7bd",
+                            "name": "The request was rejected related to limit-exceeding requests. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "sites"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "d92438b7-ddf4-4611-b60a-46aa1c535b80",
+                            "name": "The request was rejected because of unknown issue. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "sites"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         }
                     ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
                 }
-            ],
-            "event": [],
-            "protocolProfileBehavior": {
-                "disableBodyPruning": true
-            }
+            ]
         },
         {
-            "id": "deee573f-e9e2-4518-9440-9d75116402e9",
-            "name": "List subjects",
-            "request": {
-                "name": "List subjects",
-                "description": {
-                    "content": "Returns all subjects enrolled in the study.",
-                    "type": "text/plain"
-                },
-                "url": {
-                    "path": [
-                        "studies",
-                        ":studyKey",
-                        "subjects"
-                    ],
-                    "host": [
-                        "{{baseUrl}}"
-                    ],
-                    "query": [
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "page",
-                            "value": "0"
+            "name": "Subjects",
+            "description": "Enrolled subjects",
+            "item": [
+                {
+                    "id": "4ccb10b6-95ea-40cc-9e8e-bd0ff70a0d12",
+                    "name": "List subjects",
+                    "request": {
+                        "name": "List subjects",
+                        "description": {
+                            "content": "Returns all subjects enrolled in the study.",
+                            "type": "text/plain"
                         },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "size",
-                            "value": "25"
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "subjects"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "filter",
+                                    "value": "<string>"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "value": "<string>",
+                                    "key": "studyKey",
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "(Required) ",
+                                        "type": "text/plain"
+                                    }
+                                }
+                            ]
                         },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "sort",
-                            "value": "<string>"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                "type": "text/plain"
-                            },
-                            "key": "filter",
-                            "value": "<string>"
-                        }
-                    ],
-                    "variable": [
-                        {
-                            "type": "any",
-                            "value": "<string>",
-                            "key": "studyKey",
-                            "disabled": false,
-                            "description": {
-                                "content": "(Required) ",
-                                "type": "text/plain"
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
                             }
+                        ],
+                        "method": "GET",
+                        "body": {},
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "c4804799-4242-4924-b512-50107e79f508",
+                            "name": "Subject list",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "subjects"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectKey\": \"<string>\",\n      \"subjectStatus\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"siteName\": \"<string>\",\n      \"deleted\": \"<boolean>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectKey\": \"<string>\",\n      \"subjectStatus\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"siteName\": \"<string>\",\n      \"deleted\": \"<boolean>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "2d112af9-97d3-4a6f-9b9e-449c22e5e837",
+                            "name": "The request was malformed. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "subjects"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "1c466d72-7535-43dd-a775-41bbfe3fabeb",
+                            "name": "The request was rejected related to security issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "subjects"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "99afb6cd-fbb7-46ec-afa3-631e1ebfcc94",
+                            "name": "The request was rejected related to security issue, likely an invalid studyKey. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "subjects"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "d4157af5-5b07-46ca-9889-bad36104ae3d",
+                            "name": "The request was rejected related to invalid resource issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "subjects"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Not Found",
+                            "code": 404,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "2dce05f6-70cf-42e5-8f62-5e38214c5032",
+                            "name": "The request was rejected related to limit-exceeding requests. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "subjects"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "bddeaa25-5180-4d75-9222-47ca093f80d8",
+                            "name": "The request was rejected because of unknown issue. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "subjects"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         }
-                    ]
-                },
-                "header": [
-                    {
-                        "key": "Accept",
-                        "value": "application/json"
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
                     }
-                ],
-                "method": "GET",
-                "body": {},
-                "auth": null
-            },
-            "response": [
-                {
-                    "id": "53a47abf-5a57-4bc4-b1ed-270d02bf263b",
-                    "name": "Subject list",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "subjects"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "filter",
-                                    "value": "<string>"
-                                }
-                            ],
-                            "variable": []
-                        },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "OK",
-                    "code": 200,
-                    "header": [
-                        {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectKey\": \"<string>\",\n      \"subjectStatus\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"siteName\": \"<string>\",\n      \"deleted\": \"<boolean>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectKey\": \"<string>\",\n      \"subjectStatus\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"siteName\": \"<string>\",\n      \"deleted\": \"<boolean>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    }\n  ]\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "d1af4ee6-435d-44b2-9686-63983404dbe3",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "subjects"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "filter",
-                                    "value": "<string>"
-                                }
-                            ],
-                            "variable": []
-                        },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Bad Request",
-                    "code": 400,
-                    "header": [
-                        {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "fba63bd3-b2b3-4069-aac9-4e1a89d6b720",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "subjects"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "filter",
-                                    "value": "<string>"
-                                }
-                            ],
-                            "variable": []
-                        },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Unauthorized",
-                    "code": 401,
-                    "header": [
-                        {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
                 }
-            ],
-            "event": [],
-            "protocolProfileBehavior": {
-                "disableBodyPruning": true
-            }
+            ]
         },
         {
-            "id": "6ece2b76-414e-4554-92df-4fb80b413095",
-            "name": "List records",
-            "request": {
-                "name": "List records",
-                "description": {
-                    "content": "Returns eCRF record instances for the study.\nFilter attributes: ``intervalId``, ``formId``, ``formKey``, ``siteId``,\n``recordId``, ``parentRecordId``, ``recordType``, ``recordStatus``,\n``subjectKey``, ``dateCreated`` and ``dateModified``.\n",
-                    "type": "text/plain"
-                },
-                "url": {
-                    "path": [
-                        "studies",
-                        ":studyKey",
-                        "records"
-                    ],
-                    "host": [
-                        "{{baseUrl}}"
-                    ],
-                    "query": [
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "page",
-                            "value": "0"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "size",
-                            "value": "25"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "sort",
-                            "value": "<string>"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                "type": "text/plain"
-                            },
-                            "key": "filter",
-                            "value": "<string>"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "Search criteria for values within ``recordData``. Supports the\nsame operators as ``filter`` with the addition of ``=~`` for\ncase-insensitive contains. Separate multiple conditions with\n``;`` for AND or ``,`` for OR but do not mix both connectors in\none request.\n",
-                                "type": "text/plain"
-                            },
-                            "key": "recordDataFilter",
-                            "value": "<string>"
-                        }
-                    ],
-                    "variable": [
-                        {
-                            "type": "any",
-                            "value": "<string>",
-                            "key": "studyKey",
-                            "disabled": false,
-                            "description": {
-                                "content": "(Required) ",
-                                "type": "text/plain"
-                            }
-                        }
-                    ]
-                },
-                "header": [
-                    {
-                        "key": "Accept",
-                        "value": "application/json"
-                    }
-                ],
-                "method": "GET",
-                "body": {},
-                "auth": null
-            },
-            "response": [
+            "name": "Records",
+            "description": "eCRF record instances",
+            "item": [
                 {
-                    "id": "760f5fb6-3d0a-44e5-bc9a-a85816efc543",
-                    "name": "Record list",
-                    "originalRequest": {
+                    "id": "69074a09-b718-4639-a3e0-78e961a9ab2f",
+                    "name": "List records",
+                    "request": {
+                        "name": "List records",
+                        "description": {
+                            "content": "Returns eCRF record instances for the study.\nFilter attributes: ``intervalId``, ``formId``, ``formKey``, ``siteId``,\n``recordId``, ``parentRecordId``, ``recordType``, ``recordStatus``,\n``subjectKey``, ``dateCreated`` and ``dateModified``.\n",
+                            "type": "text/plain"
+                        },
                         "url": {
                             "path": [
                                 "studies",
@@ -2302,41 +4002,626 @@
                                     "value": "<string>"
                                 }
                             ],
-                            "variable": []
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "value": "<string>",
+                                    "key": "studyKey",
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "(Required) ",
+                                        "type": "text/plain"
+                                    }
+                                }
+                            ]
                         },
                         "header": [
                             {
                                 "key": "Accept",
                                 "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
                             }
                         ],
                         "method": "GET",
-                        "body": {}
+                        "body": {},
+                        "auth": null
                     },
-                    "status": "OK",
-                    "code": 200,
-                    "header": [
+                    "response": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
+                            "id": "bb15d380-8530-4380-8850-983accad8820",
+                            "name": "Record list",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "records"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Search criteria for values within ``recordData``. Supports the\nsame operators as ``filter`` with the addition of ``=~`` for\ncase-insensitive contains. Separate multiple conditions with\n``;`` for AND or ``,`` for OR but do not mix both connectors in\none request.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "recordDataFilter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"intervalId\": \"<integer>\",\n      \"formId\": \"<integer>\",\n      \"formKey\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"recordId\": \"<integer>\",\n      \"recordOid\": \"<string>\",\n      \"recordType\": \"<string>\",\n      \"recordStatus\": \"<string>\",\n      \"deleted\": \"<boolean>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectOid\": \"<string>\",\n      \"subjectKey\": \"<string>\",\n      \"visitId\": \"<integer>\",\n      \"parentRecordId\": \"<integer>\",\n      \"recordData\": {}\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"intervalId\": \"<integer>\",\n      \"formId\": \"<integer>\",\n      \"formKey\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"recordId\": \"<integer>\",\n      \"recordOid\": \"<string>\",\n      \"recordType\": \"<string>\",\n      \"recordStatus\": \"<string>\",\n      \"deleted\": \"<boolean>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectOid\": \"<string>\",\n      \"subjectKey\": \"<string>\",\n      \"visitId\": \"<integer>\",\n      \"parentRecordId\": \"<integer>\",\n      \"recordData\": {}\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "4568e30c-bbee-4204-999a-c332498384d7",
+                            "name": "The request was malformed. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "records"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Search criteria for values within ``recordData``. Supports the\nsame operators as ``filter`` with the addition of ``=~`` for\ncase-insensitive contains. Separate multiple conditions with\n``;`` for AND or ``,`` for OR but do not mix both connectors in\none request.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "recordDataFilter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "3622c6db-2e69-4e28-a1ec-8b98c2d5bacb",
+                            "name": "The request was rejected related to security issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "records"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Search criteria for values within ``recordData``. Supports the\nsame operators as ``filter`` with the addition of ``=~`` for\ncase-insensitive contains. Separate multiple conditions with\n``;`` for AND or ``,`` for OR but do not mix both connectors in\none request.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "recordDataFilter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "fe34021a-996c-47cd-a607-f1676f1b1895",
+                            "name": "The request was rejected related to security issue, likely an invalid studyKey. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "records"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Search criteria for values within ``recordData``. Supports the\nsame operators as ``filter`` with the addition of ``=~`` for\ncase-insensitive contains. Separate multiple conditions with\n``;`` for AND or ``,`` for OR but do not mix both connectors in\none request.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "recordDataFilter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "cf24de61-1351-4a35-a2f8-6a55b1a24c43",
+                            "name": "The request was rejected related to invalid resource issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "records"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Search criteria for values within ``recordData``. Supports the\nsame operators as ``filter`` with the addition of ``=~`` for\ncase-insensitive contains. Separate multiple conditions with\n``;`` for AND or ``,`` for OR but do not mix both connectors in\none request.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "recordDataFilter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Not Found",
+                            "code": 404,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "f60359d1-119b-4594-ac31-d8d0f5d871bb",
+                            "name": "The request was rejected related to limit-exceeding requests. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "records"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Search criteria for values within ``recordData``. Supports the\nsame operators as ``filter`` with the addition of ``=~`` for\ncase-insensitive contains. Separate multiple conditions with\n``;`` for AND or ``,`` for OR but do not mix both connectors in\none request.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "recordDataFilter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "09533130-eec6-4112-979d-9facd29e014b",
+                            "name": "The request was rejected because of unknown issue. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "records"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Search criteria for values within ``recordData``. Supports the\nsame operators as ``filter`` with the addition of ``=~`` for\ncase-insensitive contains. Separate multiple conditions with\n``;`` for AND or ``,`` for OR but do not mix both connectors in\none request.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "recordDataFilter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         }
                     ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"intervalId\": \"<integer>\",\n      \"formId\": \"<integer>\",\n      \"formKey\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"recordId\": \"<integer>\",\n      \"recordOid\": \"<string>\",\n      \"recordType\": \"<string>\",\n      \"recordStatus\": \"<string>\",\n      \"deleted\": \"<boolean>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectOid\": \"<string>\",\n      \"subjectKey\": \"<string>\",\n      \"visitId\": \"<integer>\",\n      \"parentRecordId\": \"<integer>\",\n      \"recordData\": {}\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"intervalId\": \"<integer>\",\n      \"formId\": \"<integer>\",\n      \"formKey\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"recordId\": \"<integer>\",\n      \"recordOid\": \"<string>\",\n      \"recordType\": \"<string>\",\n      \"recordStatus\": \"<string>\",\n      \"deleted\": \"<boolean>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectOid\": \"<string>\",\n      \"subjectKey\": \"<string>\",\n      \"visitId\": \"<integer>\",\n      \"parentRecordId\": \"<integer>\",\n      \"recordData\": {}\n    }\n  ]\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
                 },
                 {
-                    "id": "df8899be-ac20-4612-904f-c9882c8f275a",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
+                    "id": "20cdaedf-886a-4fd2-ac67-9b59b47c67f6",
+                    "name": "Create records",
+                    "request": {
+                        "name": "Create records",
+                        "description": {
+                            "content": "Adds new records and returns a job for asynchronous processing.",
+                            "type": "text/plain"
+                        },
                         "url": {
                             "path": [
                                 "studies",
@@ -2346,501 +4631,415 @@
                             "host": [
                                 "{{baseUrl}}"
                             ],
-                            "query": [
+                            "query": [],
+                            "variable": [
                                 {
+                                    "type": "any",
+                                    "value": "<string>",
+                                    "key": "studyKey",
                                     "disabled": false,
                                     "description": {
-                                        "content": "",
+                                        "content": "(Required) ",
                                         "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "filter",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "Search criteria for values within ``recordData``. Supports the\nsame operators as ``filter`` with the addition of ``=~`` for\ncase-insensitive contains. Separate multiple conditions with\n``;`` for AND or ``,`` for OR but do not mix both connectors in\none request.\n",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "recordDataFilter",
-                                    "value": "<string>"
+                                    }
                                 }
-                            ],
-                            "variable": []
+                            ]
                         },
                         "header": [
                             {
-                                "key": "Accept",
+                                "key": "Content-Type",
                                 "value": "application/json"
                             },
                             {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
+                                "key": "Accept",
+                                "value": "application/json"
                             }
                         ],
-                        "method": "GET",
-                        "body": {}
+                        "method": "POST",
+                        "body": {
+                            "mode": "raw",
+                            "raw": "[\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  },\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  }\n]",
+                            "options": {
+                                "raw": {
+                                    "headerFamily": "json",
+                                    "language": "json"
+                                }
+                            }
+                        },
+                        "auth": null
                     },
-                    "status": "Bad Request",
-                    "code": 400,
-                    "header": [
+                    "response": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "24060216-e0d4-482b-8e97-c0b5d190cd21",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "records"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
+                            "id": "998f34a0-522b-472d-88e1-cce8d8e50d42",
+                            "name": "Job created",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "records"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
                                 },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
                                     },
-                                    "key": "size",
-                                    "value": "25"
-                                },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "[\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  },\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  }\n]",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Accepted",
+                            "code": 202,
+                            "header": [
                                 {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "filter",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "Search criteria for values within ``recordData``. Supports the\nsame operators as ``filter`` with the addition of ``=~`` for\ncase-insensitive contains. Separate multiple conditions with\n``;`` for AND or ``,`` for OR but do not mix both connectors in\none request.\n",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "recordDataFilter",
-                                    "value": "<string>"
+                                    "key": "Content-Type",
+                                    "value": "application/json"
                                 }
                             ],
-                            "variable": []
+                            "body": "{\n  \"jobId\": \"<string>\",\n  \"batchId\": \"<string>\",\n  \"state\": \"<string>\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Unauthorized",
-                    "code": 401,
-                    "header": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
+                            "id": "b4db83f9-ddbc-4d6f-9b38-c1f69dba3886",
+                            "name": "The request was malformed. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "records"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "[\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  },\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  }\n]",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "4a0de2ab-32bc-4204-92f8-a619bf84fb3e",
+                            "name": "The request was rejected related to security issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "records"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "[\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  },\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  }\n]",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "72aac606-482e-4fde-9f17-9d01ae5260da",
+                            "name": "The request was rejected related to security issue, likely an invalid studyKey. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "records"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "[\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  },\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  }\n]",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "5e44a85f-3f9b-467d-b879-f6053c808db7",
+                            "name": "The request was rejected related to invalid resource issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "records"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "[\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  },\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  }\n]",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Not Found",
+                            "code": 404,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "65b64bae-6a87-4d79-9419-bdbab33fad70",
+                            "name": "The request was rejected related to limit-exceeding requests. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "records"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "[\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  },\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  }\n]",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "dc81b24f-bfad-453c-a2a6-74dde68ba433",
+                            "name": "The request was rejected because of unknown issue. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "records"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "[\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  },\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  }\n]",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                }
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         }
                     ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
                 }
-            ],
-            "event": [],
-            "protocolProfileBehavior": {
-                "disableBodyPruning": true
-            }
+            ]
         },
         {
-            "id": "d5c9fc16-a148-417c-bc6a-de89afd77eec",
-            "name": "Create records",
-            "request": {
-                "name": "Create records",
-                "description": {
-                    "content": "Adds new records and returns a job for asynchronous processing.",
-                    "type": "text/plain"
-                },
-                "url": {
-                    "path": [
-                        "studies",
-                        ":studyKey",
-                        "records"
-                    ],
-                    "host": [
-                        "{{baseUrl}}"
-                    ],
-                    "query": [],
-                    "variable": [
-                        {
-                            "type": "any",
-                            "value": "<string>",
-                            "key": "studyKey",
-                            "disabled": false,
-                            "description": {
-                                "content": "(Required) ",
-                                "type": "text/plain"
-                            }
-                        }
-                    ]
-                },
-                "header": [
-                    {
-                        "key": "Content-Type",
-                        "value": "application/json"
-                    },
-                    {
-                        "key": "Accept",
-                        "value": "application/json"
-                    }
-                ],
-                "method": "POST",
-                "body": {
-                    "mode": "raw",
-                    "raw": "[\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  },\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  }\n]",
-                    "options": {
-                        "raw": {
-                            "headerFamily": "json",
-                            "language": "json"
-                        }
-                    }
-                },
-                "auth": null
-            },
-            "response": [
+            "name": "RecordRevisions",
+            "description": "Change history for records",
+            "item": [
                 {
-                    "id": "65ae8510-5da7-4280-bc87-d0377bfd3361",
-                    "name": "Job created",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "records"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [],
-                            "variable": []
+                    "id": "71eccce5-0748-490d-845c-9dfd2367c9c8",
+                    "name": "List record revisions",
+                    "request": {
+                        "name": "List record revisions",
+                        "description": {
+                            "content": "Returns revision history for records in the study.\nFilter attributes: ``recordRevisionId``, ``recordId``, ``recordOid``,\n``recordRevision``, ``dataRevision``, ``recordStatus``, ``user``,\n``reasonForChange`` and ``dateCreated``.\n",
+                            "type": "text/plain"
                         },
-                        "header": [
-                            {
-                                "key": "Content-Type",
-                                "value": "application/json"
-                            },
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "POST",
-                        "body": {
-                            "mode": "raw",
-                            "raw": "[\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  },\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  }\n]",
-                            "options": {
-                                "raw": {
-                                    "headerFamily": "json",
-                                    "language": "json"
-                                }
-                            }
-                        }
-                    },
-                    "status": "Accepted",
-                    "code": 202,
-                    "header": [
-                        {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"jobId\": \"<string>\",\n  \"batchId\": \"<string>\",\n  \"state\": \"<string>\"\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "37d5cc61-b411-492a-9770-6d9a05bf02c9",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "records"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [],
-                            "variable": []
-                        },
-                        "header": [
-                            {
-                                "key": "Content-Type",
-                                "value": "application/json"
-                            },
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "POST",
-                        "body": {
-                            "mode": "raw",
-                            "raw": "[\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  },\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  }\n]",
-                            "options": {
-                                "raw": {
-                                    "headerFamily": "json",
-                                    "language": "json"
-                                }
-                            }
-                        }
-                    },
-                    "status": "Bad Request",
-                    "code": 400,
-                    "header": [
-                        {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "a202bc31-086c-4fb6-9f1e-2ff47b717e66",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "records"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [],
-                            "variable": []
-                        },
-                        "header": [
-                            {
-                                "key": "Content-Type",
-                                "value": "application/json"
-                            },
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "POST",
-                        "body": {
-                            "mode": "raw",
-                            "raw": "[\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  },\n  {\n    \"formKey\": \"<string>\",\n    \"subjectKey\": \"<string>\",\n    \"siteName\": \"<string>\",\n    \"intervalName\": \"<string>\",\n    \"data\": {}\n  }\n]",
-                            "options": {
-                                "raw": {
-                                    "headerFamily": "json",
-                                    "language": "json"
-                                }
-                            }
-                        }
-                    },
-                    "status": "Unauthorized",
-                    "code": 401,
-                    "header": [
-                        {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                }
-            ],
-            "event": [],
-            "protocolProfileBehavior": {
-                "disableBodyPruning": true
-            }
-        },
-        {
-            "id": "efe870d8-4ec5-4c6e-b807-20c334a589be",
-            "name": "List record revisions",
-            "request": {
-                "name": "List record revisions",
-                "description": {
-                    "content": "Returns revision history for records in the study.\nFilter attributes: ``recordRevisionId``, ``recordId``, ``recordOid``,\n``recordRevision``, ``dataRevision``, ``recordStatus``, ``user``,\n``reasonForChange`` and ``dateCreated``.\n",
-                    "type": "text/plain"
-                },
-                "url": {
-                    "path": [
-                        "studies",
-                        ":studyKey",
-                        "recordRevisions"
-                    ],
-                    "host": [
-                        "{{baseUrl}}"
-                    ],
-                    "query": [
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "page",
-                            "value": "0"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "size",
-                            "value": "25"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "sort",
-                            "value": "<string>"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                "type": "text/plain"
-                            },
-                            "key": "filter",
-                            "value": "<string>"
-                        }
-                    ],
-                    "variable": [
-                        {
-                            "type": "any",
-                            "value": "<string>",
-                            "key": "studyKey",
-                            "disabled": false,
-                            "description": {
-                                "content": "(Required) ",
-                                "type": "text/plain"
-                            }
-                        }
-                    ]
-                },
-                "header": [
-                    {
-                        "key": "Accept",
-                        "value": "application/json"
-                    }
-                ],
-                "method": "GET",
-                "body": {},
-                "auth": null
-            },
-            "response": [
-                {
-                    "id": "b7e7133d-0abe-4371-b095-a907f5236295",
-                    "name": "Record revision list",
-                    "originalRequest": {
                         "url": {
                             "path": [
                                 "studies",
@@ -2888,291 +5087,569 @@
                                     "value": "<string>"
                                 }
                             ],
-                            "variable": []
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "value": "<string>",
+                                    "key": "studyKey",
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "(Required) ",
+                                        "type": "text/plain"
+                                    }
+                                }
+                            ]
                         },
                         "header": [
                             {
                                 "key": "Accept",
                                 "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
                             }
                         ],
                         "method": "GET",
-                        "body": {}
+                        "body": {},
+                        "auth": null
                     },
-                    "status": "OK",
-                    "code": 200,
-                    "header": [
+                    "response": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"recordRevisionId\": \"<integer>\",\n      \"recordId\": \"<integer>\",\n      \"recordRevision\": \"<integer>\",\n      \"dataRevision\": \"<integer>\",\n      \"recordStatus\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectKey\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"formKey\": \"<string>\",\n      \"intervalId\": \"<integer>\",\n      \"deleted\": \"<boolean>\",\n      \"dateCreated\": \"<string>\"\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"recordRevisionId\": \"<integer>\",\n      \"recordId\": \"<integer>\",\n      \"recordRevision\": \"<integer>\",\n      \"dataRevision\": \"<integer>\",\n      \"recordStatus\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectKey\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"formKey\": \"<string>\",\n      \"intervalId\": \"<integer>\",\n      \"deleted\": \"<boolean>\",\n      \"dateCreated\": \"<string>\"\n    }\n  ]\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "a1ad7b0d-29a8-445e-b478-019fc7b5d9e7",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "recordRevisions"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
+                            "id": "88208d44-83b8-4e57-9ef8-a5d8f760ddc1",
+                            "name": "Record revision list",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "recordRevisions"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
                                 },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
                                 {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "filter",
-                                    "value": "<string>"
+                                    "key": "Content-Type",
+                                    "value": "application/json"
                                 }
                             ],
-                            "variable": []
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"recordRevisionId\": \"<integer>\",\n      \"recordId\": \"<integer>\",\n      \"recordRevision\": \"<integer>\",\n      \"dataRevision\": \"<integer>\",\n      \"recordStatus\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectKey\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"formKey\": \"<string>\",\n      \"intervalId\": \"<integer>\",\n      \"deleted\": \"<boolean>\",\n      \"dateCreated\": \"<string>\"\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"recordRevisionId\": \"<integer>\",\n      \"recordId\": \"<integer>\",\n      \"recordRevision\": \"<integer>\",\n      \"dataRevision\": \"<integer>\",\n      \"recordStatus\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectKey\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"formKey\": \"<string>\",\n      \"intervalId\": \"<integer>\",\n      \"deleted\": \"<boolean>\",\n      \"dateCreated\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Bad Request",
-                    "code": 400,
-                    "header": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "690e5eda-e1a0-4b59-a730-104dd2c65d3f",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "recordRevisions"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
+                            "id": "7f251eeb-c8d8-4034-a9d2-1d1dc6781b54",
+                            "name": "The request was malformed. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "recordRevisions"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
                                 },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
                                 {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "filter",
-                                    "value": "<string>"
+                                    "key": "Content-Type",
+                                    "value": "application/json"
                                 }
                             ],
-                            "variable": []
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Unauthorized",
-                    "code": 401,
-                    "header": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
+                            "id": "a8082ca9-489f-4703-8015-2c1d7db3626d",
+                            "name": "The request was rejected related to security issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "recordRevisions"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "669b9052-4583-4fb9-8897-4dc0a89111c1",
+                            "name": "The request was rejected related to security issue, likely an invalid studyKey. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "recordRevisions"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "bf4f7004-8b39-4654-a73c-56b1a38ec5f7",
+                            "name": "The request was rejected related to invalid resource issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "recordRevisions"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Not Found",
+                            "code": 404,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "5124ac15-1ba3-46ca-bcf1-0bbf9c84c0a8",
+                            "name": "The request was rejected related to limit-exceeding requests. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "recordRevisions"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "71f1832e-35ac-4e23-9720-321bf26d78d6",
+                            "name": "The request was rejected because of unknown issue. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "recordRevisions"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         }
                     ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
                 }
-            ],
-            "event": [],
-            "protocolProfileBehavior": {
-                "disableBodyPruning": true
-            }
+            ]
         },
         {
-            "id": "19afb6a7-5612-4915-a5b4-06950c605440",
-            "name": "List codings",
-            "request": {
-                "name": "List codings",
-                "description": {
-                    "content": "Returns medical coding history entries for the study.\nFilter attributes: ``siteId``, ``subjectId``, ``formId``, ``recordId``,\n``revision``, ``variable``, ``value``, ``code``, ``codedBy``, ``reason``,\n``dictionaryName``, ``dictionaryVersion`` and ``dateCoded``.\n",
-                    "type": "text/plain"
-                },
-                "url": {
-                    "path": [
-                        "studies",
-                        ":studyKey",
-                        "codings"
-                    ],
-                    "host": [
-                        "{{baseUrl}}"
-                    ],
-                    "query": [
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "page",
-                            "value": "0"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "size",
-                            "value": "25"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "sort",
-                            "value": "<string>"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                "type": "text/plain"
-                            },
-                            "key": "filter",
-                            "value": "<string>"
-                        }
-                    ],
-                    "variable": [
-                        {
-                            "type": "any",
-                            "value": "<string>",
-                            "key": "studyKey",
-                            "disabled": false,
-                            "description": {
-                                "content": "(Required) ",
-                                "type": "text/plain"
-                            }
-                        }
-                    ]
-                },
-                "header": [
-                    {
-                        "key": "Accept",
-                        "value": "application/json"
-                    }
-                ],
-                "method": "GET",
-                "body": {},
-                "auth": null
-            },
-            "response": [
+            "name": "Codings",
+            "description": "Medical coding history",
+            "item": [
                 {
-                    "id": "121187af-683e-4fa0-90a4-4cbc7c74c0af",
-                    "name": "Coding list",
-                    "originalRequest": {
+                    "id": "64aeef51-fb87-48c5-8fe8-4eb8980449cb",
+                    "name": "List codings",
+                    "request": {
+                        "name": "List codings",
+                        "description": {
+                            "content": "Returns medical coding history entries for the study.\nFilter attributes: ``siteId``, ``subjectId``, ``formId``, ``recordId``,\n``revision``, ``variable``, ``value``, ``code``, ``codedBy``, ``reason``,\n``dictionaryName``, ``dictionaryVersion`` and ``dateCoded``.\n",
+                            "type": "text/plain"
+                        },
                         "url": {
                             "path": [
                                 "studies",
@@ -3220,291 +5697,569 @@
                                     "value": "<string>"
                                 }
                             ],
-                            "variable": []
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "value": "<string>",
+                                    "key": "studyKey",
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "(Required) ",
+                                        "type": "text/plain"
+                                    }
+                                }
+                            ]
                         },
                         "header": [
                             {
                                 "key": "Accept",
                                 "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
                             }
                         ],
                         "method": "GET",
-                        "body": {}
+                        "body": {},
+                        "auth": null
                     },
-                    "status": "OK",
-                    "code": 200,
-                    "header": [
+                    "response": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"siteName\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectKey\": \"<string>\",\n      \"formId\": \"<integer>\",\n      \"formName\": \"<string>\",\n      \"formKey\": \"<string>\",\n      \"recordId\": \"<integer>\",\n      \"variable\": \"<string>\",\n      \"value\": \"<string>\",\n      \"codingId\": \"<integer>\",\n      \"code\": \"<string>\",\n      \"codedBy\": \"<string>\",\n      \"dictionaryName\": \"<string>\",\n      \"dictionaryVersion\": \"<string>\",\n      \"dateCoded\": \"<string>\"\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"siteName\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectKey\": \"<string>\",\n      \"formId\": \"<integer>\",\n      \"formName\": \"<string>\",\n      \"formKey\": \"<string>\",\n      \"recordId\": \"<integer>\",\n      \"variable\": \"<string>\",\n      \"value\": \"<string>\",\n      \"codingId\": \"<integer>\",\n      \"code\": \"<string>\",\n      \"codedBy\": \"<string>\",\n      \"dictionaryName\": \"<string>\",\n      \"dictionaryVersion\": \"<string>\",\n      \"dateCoded\": \"<string>\"\n    }\n  ]\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "cec7c1de-d635-4f17-bf43-bec368a19fc1",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "codings"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
+                            "id": "33867035-be8d-48ab-a961-370a58264b12",
+                            "name": "Coding list",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "codings"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
                                 },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
                                 {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "filter",
-                                    "value": "<string>"
+                                    "key": "Content-Type",
+                                    "value": "application/json"
                                 }
                             ],
-                            "variable": []
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"siteName\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectKey\": \"<string>\",\n      \"formId\": \"<integer>\",\n      \"formName\": \"<string>\",\n      \"formKey\": \"<string>\",\n      \"recordId\": \"<integer>\",\n      \"variable\": \"<string>\",\n      \"value\": \"<string>\",\n      \"codingId\": \"<integer>\",\n      \"code\": \"<string>\",\n      \"codedBy\": \"<string>\",\n      \"dictionaryName\": \"<string>\",\n      \"dictionaryVersion\": \"<string>\",\n      \"dateCoded\": \"<string>\"\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"siteName\": \"<string>\",\n      \"siteId\": \"<integer>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectKey\": \"<string>\",\n      \"formId\": \"<integer>\",\n      \"formName\": \"<string>\",\n      \"formKey\": \"<string>\",\n      \"recordId\": \"<integer>\",\n      \"variable\": \"<string>\",\n      \"value\": \"<string>\",\n      \"codingId\": \"<integer>\",\n      \"code\": \"<string>\",\n      \"codedBy\": \"<string>\",\n      \"dictionaryName\": \"<string>\",\n      \"dictionaryVersion\": \"<string>\",\n      \"dateCoded\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Bad Request",
-                    "code": 400,
-                    "header": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "be1d2ebb-adb8-43f3-89ad-16ae81426334",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "codings"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
+                            "id": "5d5ad89f-ad17-4b9a-91e7-2fbae7478320",
+                            "name": "The request was malformed. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "codings"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
                                 },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
                                 {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "filter",
-                                    "value": "<string>"
+                                    "key": "Content-Type",
+                                    "value": "application/json"
                                 }
                             ],
-                            "variable": []
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Unauthorized",
-                    "code": 401,
-                    "header": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
+                            "id": "84cad24a-c484-4b6b-9767-4d59d84ea012",
+                            "name": "The request was rejected related to security issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "codings"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "d378857b-912c-4a7d-b987-ec6612166000",
+                            "name": "The request was rejected related to security issue, likely an invalid studyKey. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "codings"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "a26d74e3-a9a3-4a2a-bc3f-7a1fc7db1fed",
+                            "name": "The request was rejected related to invalid resource issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "codings"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Not Found",
+                            "code": 404,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "5cc3e41c-91e5-49dc-a0b6-8847f7bdf7f4",
+                            "name": "The request was rejected related to limit-exceeding requests. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "codings"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "f19c2d3a-68eb-42c5-bc1f-2e7a1c3707a4",
+                            "name": "The request was rejected because of unknown issue. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "codings"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         }
                     ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
                 }
-            ],
-            "event": [],
-            "protocolProfileBehavior": {
-                "disableBodyPruning": true
-            }
+            ]
         },
         {
-            "id": "234325a5-a7b3-493c-859e-329316c1dd23",
-            "name": "List queries",
-            "request": {
-                "name": "List queries",
-                "description": {
-                    "content": "Returns queries associated with the study.",
-                    "type": "text/plain"
-                },
-                "url": {
-                    "path": [
-                        "studies",
-                        ":studyKey",
-                        "queries"
-                    ],
-                    "host": [
-                        "{{baseUrl}}"
-                    ],
-                    "query": [
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "page",
-                            "value": "0"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "size",
-                            "value": "25"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "sort",
-                            "value": "<string>"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                "type": "text/plain"
-                            },
-                            "key": "filter",
-                            "value": "<string>"
-                        }
-                    ],
-                    "variable": [
-                        {
-                            "type": "any",
-                            "value": "<string>",
-                            "key": "studyKey",
-                            "disabled": false,
-                            "description": {
-                                "content": "(Required) ",
-                                "type": "text/plain"
-                            }
-                        }
-                    ]
-                },
-                "header": [
-                    {
-                        "key": "Accept",
-                        "value": "application/json"
-                    }
-                ],
-                "method": "GET",
-                "body": {},
-                "auth": null
-            },
-            "response": [
+            "name": "Queries",
+            "description": "Data queries",
+            "item": [
                 {
-                    "id": "69c4ecdc-fa45-4c93-8b10-02770e63b8bb",
-                    "name": "Query list",
-                    "originalRequest": {
+                    "id": "60f97975-874d-4454-af82-0bcea991ec5f",
+                    "name": "List queries",
+                    "request": {
+                        "name": "List queries",
+                        "description": {
+                            "content": "Returns queries associated with the study.",
+                            "type": "text/plain"
+                        },
                         "url": {
                             "path": [
                                 "studies",
@@ -3552,291 +6307,569 @@
                                     "value": "<string>"
                                 }
                             ],
-                            "variable": []
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "value": "<string>",
+                                    "key": "studyKey",
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "(Required) ",
+                                        "type": "text/plain"
+                                    }
+                                }
+                            ]
                         },
                         "header": [
                             {
                                 "key": "Accept",
                                 "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
                             }
                         ],
                         "method": "GET",
-                        "body": {}
+                        "body": {},
+                        "auth": null
                     },
-                    "status": "OK",
-                    "code": 200,
-                    "header": [
+                    "response": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"annotationId\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"recordId\": \"<integer>\",\n      \"variable\": \"<string>\",\n      \"subjectKey\": \"<string>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"annotationId\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"recordId\": \"<integer>\",\n      \"variable\": \"<string>\",\n      \"subjectKey\": \"<string>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    }\n  ]\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "7bf401f0-b334-426a-9e24-043d1c6cb7e8",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "queries"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
+                            "id": "22ca9357-64ec-4222-9399-71664555b1cf",
+                            "name": "Query list",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "queries"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
                                 },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
                                 {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "filter",
-                                    "value": "<string>"
+                                    "key": "Content-Type",
+                                    "value": "application/json"
                                 }
                             ],
-                            "variable": []
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"studyKey\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"annotationId\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"recordId\": \"<integer>\",\n      \"variable\": \"<string>\",\n      \"subjectKey\": \"<string>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    },\n    {\n      \"studyKey\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"annotationId\": \"<integer>\",\n      \"description\": \"<string>\",\n      \"recordId\": \"<integer>\",\n      \"variable\": \"<string>\",\n      \"subjectKey\": \"<string>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Bad Request",
-                    "code": 400,
-                    "header": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "63a1a50c-bd75-4c90-9e29-e9659d47f7ab",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "queries"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
+                            "id": "88318fd7-c8fb-4fcd-affa-e9da3dcbc050",
+                            "name": "The request was malformed. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "queries"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
                                 },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
                                 {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "filter",
-                                    "value": "<string>"
+                                    "key": "Content-Type",
+                                    "value": "application/json"
                                 }
                             ],
-                            "variable": []
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Unauthorized",
-                    "code": 401,
-                    "header": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
+                            "id": "2ff001f2-9f46-4d38-8593-380f06dd8a9d",
+                            "name": "The request was rejected related to security issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "queries"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "54be517a-6a44-45f0-8657-64f035919c4e",
+                            "name": "The request was rejected related to security issue, likely an invalid studyKey. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "queries"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "6caafcf4-262c-410e-a2a7-ba68e72e275f",
+                            "name": "The request was rejected related to invalid resource issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "queries"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Not Found",
+                            "code": 404,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "6fcf34b9-38b2-438a-b576-92cb8812f84a",
+                            "name": "The request was rejected related to limit-exceeding requests. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "queries"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "4f23885f-2a0a-46a8-bf9b-d6b4dbc22d55",
+                            "name": "The request was rejected because of unknown issue. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "queries"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         }
                     ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
                 }
-            ],
-            "event": [],
-            "protocolProfileBehavior": {
-                "disableBodyPruning": true
-            }
+            ]
         },
         {
-            "id": "0b40abdb-d8b6-40b1-9612-9a12785d6d8e",
-            "name": "List visits",
-            "request": {
-                "name": "List visits",
-                "description": {
-                    "content": "Returns visit data for subjects in the study.\nFilter attributes: ``intervalId``, ``intervalName``, ``intervalGroupId``,\n``intervalGroupName``, ``startDate``, ``endDate``, ``dueDate``,\n``visitDate``, ``dateCreated`` and ``dateModified``.\n",
-                    "type": "text/plain"
-                },
-                "url": {
-                    "path": [
-                        "studies",
-                        ":studyKey",
-                        "visits"
-                    ],
-                    "host": [
-                        "{{baseUrl}}"
-                    ],
-                    "query": [
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "page",
-                            "value": "0"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "size",
-                            "value": "25"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "sort",
-                            "value": "<string>"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                "type": "text/plain"
-                            },
-                            "key": "filter",
-                            "value": "<string>"
-                        }
-                    ],
-                    "variable": [
-                        {
-                            "type": "any",
-                            "value": "<string>",
-                            "key": "studyKey",
-                            "disabled": false,
-                            "description": {
-                                "content": "(Required) ",
-                                "type": "text/plain"
-                            }
-                        }
-                    ]
-                },
-                "header": [
-                    {
-                        "key": "Accept",
-                        "value": "application/json"
-                    }
-                ],
-                "method": "GET",
-                "body": {},
-                "auth": null
-            },
-            "response": [
+            "name": "Visits",
+            "description": "Subject visits",
+            "item": [
                 {
-                    "id": "f6990bb4-c11d-47b2-b684-a713b087c796",
-                    "name": "Visit list",
-                    "originalRequest": {
+                    "id": "c44ebf67-1fbf-4bde-8b5a-ec6ff794517b",
+                    "name": "List visits",
+                    "request": {
+                        "name": "List visits",
+                        "description": {
+                            "content": "Returns visit data for subjects in the study.\nFilter attributes: ``intervalId``, ``intervalName``, ``intervalGroupId``,\n``intervalGroupName``, ``startDate``, ``endDate``, ``dueDate``,\n``visitDate``, ``dateCreated`` and ``dateModified``.\n",
+                            "type": "text/plain"
+                        },
                         "url": {
                             "path": [
                                 "studies",
@@ -3884,758 +6917,1499 @@
                                     "value": "<string>"
                                 }
                             ],
-                            "variable": []
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "value": "<string>",
+                                    "key": "studyKey",
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "(Required) ",
+                                        "type": "text/plain"
+                                    }
+                                }
+                            ]
                         },
                         "header": [
                             {
                                 "key": "Accept",
                                 "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
                             }
                         ],
                         "method": "GET",
-                        "body": {}
+                        "body": {},
+                        "auth": null
                     },
-                    "status": "OK",
-                    "code": 200,
-                    "header": [
+                    "response": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"visitId\": \"<integer>\",\n      \"studyKey\": \"<string>\",\n      \"intervalId\": \"<integer>\",\n      \"intervalName\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectKey\": \"<string>\",\n      \"startDate\": \"<string>\",\n      \"endDate\": \"<string>\",\n      \"dueDate\": \"<string>\",\n      \"visitDate\": \"<string>\",\n      \"deleted\": \"<boolean>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    },\n    {\n      \"visitId\": \"<integer>\",\n      \"studyKey\": \"<string>\",\n      \"intervalId\": \"<integer>\",\n      \"intervalName\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectKey\": \"<string>\",\n      \"startDate\": \"<string>\",\n      \"endDate\": \"<string>\",\n      \"dueDate\": \"<string>\",\n      \"visitDate\": \"<string>\",\n      \"deleted\": \"<boolean>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    }\n  ]\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "396ec814-8630-4a03-b492-021019da993f",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "visits"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
+                            "id": "0aed4862-fb06-4327-abeb-d69193743b93",
+                            "name": "Visit list",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "visits"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
                                 },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
                                 {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "filter",
-                                    "value": "<string>"
+                                    "key": "Content-Type",
+                                    "value": "application/json"
                                 }
                             ],
-                            "variable": []
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"visitId\": \"<integer>\",\n      \"studyKey\": \"<string>\",\n      \"intervalId\": \"<integer>\",\n      \"intervalName\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectKey\": \"<string>\",\n      \"startDate\": \"<string>\",\n      \"endDate\": \"<string>\",\n      \"dueDate\": \"<string>\",\n      \"visitDate\": \"<string>\",\n      \"deleted\": \"<boolean>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    },\n    {\n      \"visitId\": \"<integer>\",\n      \"studyKey\": \"<string>\",\n      \"intervalId\": \"<integer>\",\n      \"intervalName\": \"<string>\",\n      \"subjectId\": \"<integer>\",\n      \"subjectKey\": \"<string>\",\n      \"startDate\": \"<string>\",\n      \"endDate\": \"<string>\",\n      \"dueDate\": \"<string>\",\n      \"visitDate\": \"<string>\",\n      \"deleted\": \"<boolean>\",\n      \"dateCreated\": \"<string>\",\n      \"dateModified\": \"<string>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Bad Request",
-                    "code": 400,
-                    "header": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "6f417897-6def-430d-bb2f-21cc107a25d9",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "visits"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
+                            "id": "9ffdf698-bc7b-4e23-8859-288a4ce659e7",
+                            "name": "The request was malformed. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "visits"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
                                 },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
                                 {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "filter",
-                                    "value": "<string>"
+                                    "key": "Content-Type",
+                                    "value": "application/json"
                                 }
                             ],
-                            "variable": []
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Unauthorized",
-                    "code": 401,
-                    "header": [
                         {
-                            "key": "Content-Type",
-                            "value": "application/json"
+                            "id": "96f8da3d-f674-4062-83b7-154dbbd585bc",
+                            "name": "The request was rejected related to security issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "visits"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "be026010-f9db-48ab-a879-f9a083dcdcbe",
+                            "name": "The request was rejected related to security issue, likely an invalid studyKey. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "visits"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "adb5901a-36b2-4b1b-82d4-670004008a30",
+                            "name": "The request was rejected related to invalid resource issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "visits"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Not Found",
+                            "code": 404,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "76be148e-e26c-4cbc-b95d-f0d199c24991",
+                            "name": "The request was rejected related to limit-exceeding requests. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "visits"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "fef84a40-7150-41b4-9f40-d7013aeeb930",
+                            "name": "The request was rejected because of unknown issue. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "visits"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "Filter criteria in ``attribute<operator>value`` form. Attributes\nmust match the response fields for the endpoint. Combine multiple\nexpressions using ``and`` or ``;`` for logical AND and ``or`` or\n``,`` for logical OR. Supported operators are ``<``, ``<=``, ``>``,\n``>=``, ``==`` and ``!=``. Dates should be formatted as\n``YYYY-MM-DDTHH:MM:SSZ``. Use ``recordDataFilter`` to search within\nthe ``recordData`` payload of a record.\n",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "filter",
+                                            "value": "<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         }
                     ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
+                    }
                 }
-            ],
-            "event": [],
-            "protocolProfileBehavior": {
-                "disableBodyPruning": true
-            }
+            ]
         },
         {
-            "id": "0aec9d45-2a31-4f8a-91ac-517cc020d8f6",
-            "name": "List users",
-            "request": {
-                "name": "List users",
-                "description": {
-                    "content": "Returns users associated with the study.",
-                    "type": "text/plain"
-                },
-                "url": {
-                    "path": [
-                        "studies",
-                        ":studyKey",
-                        "users"
-                    ],
-                    "host": [
-                        "{{baseUrl}}"
-                    ],
-                    "query": [
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "page",
-                            "value": "0"
+            "name": "Users",
+            "description": "Study users",
+            "item": [
+                {
+                    "id": "92126f66-3d93-420f-940e-880016d19217",
+                    "name": "List users",
+                    "request": {
+                        "name": "List users",
+                        "description": {
+                            "content": "Returns users associated with the study.",
+                            "type": "text/plain"
                         },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "size",
-                            "value": "25"
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "users"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "page",
+                                    "value": "0"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "size",
+                                    "value": "25"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "sort",
+                                    "value": "<string>"
+                                },
+                                {
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "",
+                                        "type": "text/plain"
+                                    },
+                                    "key": "includeInactive",
+                                    "value": "false"
+                                }
+                            ],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "value": "<string>",
+                                    "key": "studyKey",
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "(Required) ",
+                                        "type": "text/plain"
+                                    }
+                                }
+                            ]
                         },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "sort",
-                            "value": "<string>"
-                        },
-                        {
-                            "disabled": false,
-                            "description": {
-                                "content": "",
-                                "type": "text/plain"
-                            },
-                            "key": "includeInactive",
-                            "value": "false"
-                        }
-                    ],
-                    "variable": [
-                        {
-                            "type": "any",
-                            "value": "<string>",
-                            "key": "studyKey",
-                            "disabled": false,
-                            "description": {
-                                "content": "(Required) ",
-                                "type": "text/plain"
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
                             }
+                        ],
+                        "method": "GET",
+                        "body": {},
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "da8ad7db-23a6-47b6-b60c-d3c6a61cfb34",
+                            "name": "User list",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "users"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "includeInactive",
+                                            "value": "false"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"userId\": \"<string>\",\n      \"login\": \"<string>\",\n      \"firstName\": \"<string>\",\n      \"lastName\": \"<string>\",\n      \"email\": \"<string>\",\n      \"userActiveInStudy\": \"<boolean>\"\n    },\n    {\n      \"userId\": \"<string>\",\n      \"login\": \"<string>\",\n      \"firstName\": \"<string>\",\n      \"lastName\": \"<string>\",\n      \"email\": \"<string>\",\n      \"userActiveInStudy\": \"<boolean>\"\n    }\n  ]\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "358f0e74-f4e9-4951-9ccc-e9227c7abb53",
+                            "name": "The request was malformed. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "users"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "includeInactive",
+                                            "value": "false"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "9a57588b-408a-424d-8114-655068ffd1b4",
+                            "name": "The request was rejected related to security issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "users"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "includeInactive",
+                                            "value": "false"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "677eb15f-9aa7-4af7-b31d-3a410698710c",
+                            "name": "The request was rejected related to security issue, likely an invalid studyKey. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "users"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "includeInactive",
+                                            "value": "false"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "0813fcc6-ac48-498c-b3a8-ddd2abf2b7e9",
+                            "name": "The request was rejected related to invalid resource issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "users"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "includeInactive",
+                                            "value": "false"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Not Found",
+                            "code": 404,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "98a1e19b-8b0a-4e0a-8189-bfd78f4372bd",
+                            "name": "The request was rejected related to limit-exceeding requests. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "users"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "includeInactive",
+                                            "value": "false"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "4b0664ea-e39e-4762-aed3-f1bb01d88343",
+                            "name": "The request was rejected because of unknown issue. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "users"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "25"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "includeInactive",
+                                            "value": "false"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         }
-                    ]
-                },
-                "header": [
-                    {
-                        "key": "Accept",
-                        "value": "application/json"
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
                     }
-                ],
-                "method": "GET",
-                "body": {},
-                "auth": null
-            },
-            "response": [
-                {
-                    "id": "c231ae3e-f3a8-4591-b166-a46747023bc3",
-                    "name": "User list",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "users"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "includeInactive",
-                                    "value": "false"
-                                }
-                            ],
-                            "variable": []
-                        },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "OK",
-                    "code": 200,
-                    "header": [
-                        {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9001\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  },\n  \"pagination\": {\n    \"currentPage\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"totalPages\": \"<integer>\",\n    \"totalElements\": \"<integer>\",\n    \"sort\": [\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      },\n      {\n        \"property\": \"<string>\",\n        \"direction\": \"<string>\"\n      }\n    ]\n  },\n  \"data\": [\n    {\n      \"userId\": \"<string>\",\n      \"login\": \"<string>\",\n      \"firstName\": \"<string>\",\n      \"lastName\": \"<string>\",\n      \"email\": \"<string>\",\n      \"userActiveInStudy\": \"<boolean>\"\n    },\n    {\n      \"userId\": \"<string>\",\n      \"login\": \"<string>\",\n      \"firstName\": \"<string>\",\n      \"lastName\": \"<string>\",\n      \"email\": \"<string>\",\n      \"userActiveInStudy\": \"<boolean>\"\n    }\n  ]\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "f18fad7b-dd36-41cd-afaa-e3767b60f454",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "users"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "includeInactive",
-                                    "value": "false"
-                                }
-                            ],
-                            "variable": []
-                        },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Bad Request",
-                    "code": 400,
-                    "header": [
-                        {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "c7176edd-f24d-4164-ac9f-bac8bdb5ca4c",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "users"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "page",
-                                    "value": "0"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "size",
-                                    "value": "25"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "sort",
-                                    "value": "<string>"
-                                },
-                                {
-                                    "disabled": false,
-                                    "description": {
-                                        "content": "",
-                                        "type": "text/plain"
-                                    },
-                                    "key": "includeInactive",
-                                    "value": "false"
-                                }
-                            ],
-                            "variable": []
-                        },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Unauthorized",
-                    "code": 401,
-                    "header": [
-                        {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
                 }
-            ],
-            "event": [],
-            "protocolProfileBehavior": {
-                "disableBodyPruning": true
-            }
+            ]
         },
         {
-            "id": "f339ff84-1b3d-459e-9bc9-42f0b9600bb8",
-            "name": "Retrieve job status",
-            "request": {
-                "name": "Retrieve job status",
-                "description": {
-                    "content": "Checks the status of a record import job.",
-                    "type": "text/plain"
-                },
-                "url": {
-                    "path": [
-                        "studies",
-                        ":studyKey",
-                        "jobs",
-                        ":batchId"
-                    ],
-                    "host": [
-                        "{{baseUrl}}"
-                    ],
-                    "query": [],
-                    "variable": [
-                        {
-                            "type": "any",
-                            "value": "<string>",
-                            "key": "studyKey",
-                            "disabled": false,
-                            "description": {
-                                "content": "(Required) ",
-                                "type": "text/plain"
+            "name": "Jobs",
+            "description": "Background jobs",
+            "item": [
+                {
+                    "id": "a76c260d-fdb4-46a5-b064-e629c7919046",
+                    "name": "Retrieve job status",
+                    "request": {
+                        "name": "Retrieve job status",
+                        "description": {
+                            "content": "Checks the status of a record import job.",
+                            "type": "text/plain"
+                        },
+                        "url": {
+                            "path": [
+                                "studies",
+                                ":studyKey",
+                                "jobs",
+                                ":batchId"
+                            ],
+                            "host": [
+                                "{{baseUrl}}"
+                            ],
+                            "query": [],
+                            "variable": [
+                                {
+                                    "type": "any",
+                                    "value": "<string>",
+                                    "key": "studyKey",
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "(Required) ",
+                                        "type": "text/plain"
+                                    }
+                                },
+                                {
+                                    "type": "any",
+                                    "value": "<string>",
+                                    "key": "batchId",
+                                    "disabled": false,
+                                    "description": {
+                                        "content": "(Required) ",
+                                        "type": "text/plain"
+                                    }
+                                }
+                            ]
+                        },
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
                             }
+                        ],
+                        "method": "GET",
+                        "body": {},
+                        "auth": null
+                    },
+                    "response": [
+                        {
+                            "id": "e27025d6-1b50-4d00-8c68-f70ee2b00a0b",
+                            "name": "Job status",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "jobs",
+                                        ":batchId"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"jobId\": \"<string>\",\n  \"batchId\": \"<string>\",\n  \"state\": \"<string>\",\n  \"dateCreated\": \"<string>\",\n  \"dateStarted\": \"<string>\",\n  \"dateFinished\": \"<string>\",\n  \"progress\": \"<integer>\",\n  \"resultUrl\": \"<string>\"\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         },
                         {
-                            "type": "any",
-                            "value": "<string>",
-                            "key": "batchId",
-                            "disabled": false,
-                            "description": {
-                                "content": "(Required) ",
-                                "type": "text/plain"
-                            }
+                            "id": "3a5a4ff1-083e-44ac-8b53-f19c36e2775a",
+                            "name": "The request was malformed. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "jobs",
+                                        ":batchId"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "75c3f52d-aaec-4c56-aeaf-5407728d80d3",
+                            "name": "The request was rejected related to security issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "jobs",
+                                        ":batchId"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Unauthorized",
+                            "code": 401,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "0f8c0739-8cea-4cd7-837d-189963a58c1b",
+                            "name": "The request was rejected related to security issue, likely an invalid studyKey. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "jobs",
+                                        ":batchId"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Forbidden",
+                            "code": 403,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "e65f94ae-0c48-4ba8-bd4c-024d4c190754",
+                            "name": "The request was rejected related to invalid resource issue. The response body will include an error providing further information",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "jobs",
+                                        ":batchId"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Not Found",
+                            "code": 404,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "9406c319-f205-411d-9e9d-f095b62a4f6b",
+                            "name": "The request was rejected related to limit-exceeding requests. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "jobs",
+                                        ":batchId"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Too Many Requests",
+                            "code": 429,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
+                        },
+                        {
+                            "id": "8dae2956-2484-450f-8d65-5989a8f18191",
+                            "name": "The request was rejected because of unknown issue. Please contact Mednet support for assistance",
+                            "originalRequest": {
+                                "url": {
+                                    "path": [
+                                        "studies",
+                                        ":studyKey",
+                                        "jobs",
+                                        ":batchId"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {}
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"1000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
+                            "cookie": [],
+                            "_postman_previewlanguage": "json"
                         }
-                    ]
-                },
-                "header": [
-                    {
-                        "key": "Accept",
-                        "value": "application/json"
+                    ],
+                    "event": [],
+                    "protocolProfileBehavior": {
+                        "disableBodyPruning": true
                     }
-                ],
-                "method": "GET",
-                "body": {},
-                "auth": null
-            },
-            "response": [
-                {
-                    "id": "2e748943-f114-49f2-84a7-8f6bdce1f72a",
-                    "name": "Job status",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "jobs",
-                                ":batchId"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [],
-                            "variable": []
-                        },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "OK",
-                    "code": 200,
-                    "header": [
-                        {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"jobId\": \"<string>\",\n  \"batchId\": \"<string>\",\n  \"state\": \"<string>\",\n  \"dateCreated\": \"<string>\",\n  \"dateStarted\": \"<string>\",\n  \"dateFinished\": \"<string>\",\n  \"progress\": \"<integer>\",\n  \"resultUrl\": \"<string>\"\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "0d72297b-b03a-4f50-9519-b5d923c3ff20",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "jobs",
-                                ":batchId"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [],
-                            "variable": []
-                        },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Bad Request",
-                    "code": 400,
-                    "header": [
-                        {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
-                },
-                {
-                    "id": "66dca0ca-bb1a-449d-bd96-3e4a0599d447",
-                    "name": "Error information when the request fails",
-                    "originalRequest": {
-                        "url": {
-                            "path": [
-                                "studies",
-                                ":studyKey",
-                                "jobs",
-                                ":batchId"
-                            ],
-                            "host": [
-                                "{{baseUrl}}"
-                            ],
-                            "query": [],
-                            "variable": []
-                        },
-                        "header": [
-                            {
-                                "key": "Accept",
-                                "value": "application/json"
-                            },
-                            {
-                                "description": {
-                                    "content": "Added as a part of security scheme: apikey",
-                                    "type": "text/plain"
-                                },
-                                "key": "x-api-key",
-                                "value": "<API Key>"
-                            }
-                        ],
-                        "method": "GET",
-                        "body": {}
-                    },
-                    "status": "Unauthorized",
-                    "code": 401,
-                    "header": [
-                        {
-                            "key": "Content-Type",
-                            "value": "application/json"
-                        }
-                    ],
-                    "body": "{\n  \"metadata\": {\n    \"status\": \"<string>\",\n    \"method\": \"<string>\",\n    \"path\": \"<string>\",\n    \"timestamp\": \"<string>\",\n    \"error\": {\n      \"code\": \"9000\",\n      \"description\": \"<string>\",\n      \"field\": {\n        \"attribute\": \"<string>\",\n        \"value\": \"<string>\"\n      }\n    }\n  }\n}",
-                    "cookie": [],
-                    "_postman_previewlanguage": "json"
                 }
-            ],
-            "event": [],
-            "protocolProfileBehavior": {
-                "disableBodyPruning": true
-            }
+            ]
         }
     ],
-    "auth": {
-        "type": "apikey",
-        "apikey": [
-            {
-                "type": "any",
-                "value": "x-api-key",
-                "key": "key"
-            },
-            {
-                "type": "any",
-                "value": "{{apiKey}}",
-                "key": "value"
-            },
-            {
-                "type": "any",
-                "value": "header",
-                "key": "in"
-            }
-        ]
-    },
     "event": [],
     "variable": [
         {
@@ -4644,11 +8418,11 @@
         }
     ],
     "info": {
-        "_postman_id": "fbf777bf-dffd-457b-9dd6-05aa15313e0c",
+        "_postman_id": "ec9bf94a-c877-453c-b8ba-c87d33a9c3e4",
         "name": "iMednet EDC API",
         "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
         "description": {
-            "content": "Swagger specification for the iMednet EDC REST API derived from\nthe SDK documentation. The API exposes clinical study resources\nvia JSON. Requests require `x-api-key` and `x-imn-security-key`\nheaders for authentication. API keys should remain private.\nExample request using ``curl``::\n\n  curl -X GET https://edc.prod.imednetapi.com/api/v1/edc/studies/STUDYKEY/sites \\\n    -H 'x-api-key: XXXXXXXX' \\\n    -H 'x-imn-security-key: XXX-XXX-XX-XXXXXX' \\\n    -H 'Content-Type: application/json'\n\nResults may be filtered using query parameters. A ``filter`` string\naccepts attribute/operator/value pairs such as ``formId>10`` and\n``formType==SUBJECT`` combined with ``and``/``;`` or ``or``/``,``, while\n``recordDataFilter`` applies to dynamic question data. Supported\noperators include ``<``, ``<=``, ``>``, ``>=``, ``==`` and ``!=``. Dates\nuse UTC timestamps like ``YYYY-MM-DDTHH:MM:SSZ``.\n",
+            "content": "Swagger specification for the iMednet EDC REST API derived from\nthe SDK documentation. The API exposes clinical study resources\nvia JSON.\n\n**Security and Validation**\n\nAPI keys should remain secure. Mednet does not recommend sharing\nkeys or making them public. Publicly exposing your credentials can\nresult in your account being compromised. Some implementation\ndecisions can expose keys and should be avoided wherever possible\n(e.g. CORS).\n\nMaking a successful request requires authentication using request\nheaders. Valid values for the `x-api-key` and `x-imn-security-key`\nheader attributes are required to ensure secure access to your\ndata. The content of your header might look something like the\nfollowing::\n\n  {\n      \"x-api-key\": \"your-imednet-supplied-api-key\",\n      \"x-imn-security-key\": \"your-imednet-supplied-security-key\"\n  }\n\nExample request using ``curl`` to request sites from STUDYKEY::\n\n  curl -X GET https://edc.prod.imednetapi.com/api/v1/edc/studies/STUDYKEY/sites \\\n    -H 'x-api-key: XXXXXXXX' \\\n    -H 'x-imn-security-key: XXX-XXX-XX-XXXXXX' \\\n    -H 'Content-Type: application/json'\n\nResults may be filtered using query parameters. A ``filter`` string\naccepts attribute/operator/value pairs such as ``formId>10`` and\n``formType==SUBJECT`` combined with ``and``/``;`` or ``or``/``,``, while\n``recordDataFilter`` applies to dynamic question data. Supported\noperators include ``<``, ``<=``, ``>``, ``>=``, ``==`` and ``!=``. Dates\nuse UTC timestamps like ``YYYY-MM-DDTHH:MM:SSZ``.\nError responses use standard HTTP status codes to convey the reason for failure:\n  - **400 Bad Request** for invalid input parameters\n  - **401 Unauthorized** when authentication headers are missing or invalid\n  - **403 Forbidden** when the study key is invalid or access is denied\n  - **404 Not Found** when the resource does not exist\n  - **429 Too Many Requests** when request limits are exceeded\n  - **500 Internal Server Error** for unexpected failures\n",
             "type": "text/plain"
         }
     }


### PR DESCRIPTION
## Summary
- centralize error handling with explicit error responses
- remove API key security scheme to match custom header auth flow
- document Security and Validation and expected status codes in the spec description
- add operation tags for Studies, Sites, Records and more

## Testing
- `openapi-spec-validator imednet/openapi.yaml`


------
https://chatgpt.com/codex/tasks/task_e_686ec260b124832cbcc5441402a7de1c