### PR TITLE
Add API docs workflow

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -1,0 +1,27 @@
+name: Publish API docs
+
+on:
+  workflow_run:
+    workflows: ["Validate iMednet OpenAPI specification"]
+    types:
+      - completed
+  workflow_dispatch:
+
+jobs:
+  docs:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── OPTION A – ReDoc (richer UI) ───────────────────────────
+      - uses: actions/setup-node@v4
+      - run: npx redoc-cli bundle imednet/openapi.yaml -o site/index.html
+        # add --options.theme.colors.primary.main=... etc. if desired
+
+      # ── Publish to GitHub Pages ────────────────────────────────
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+      - uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- generate static API docs after validation passes
- publish docs to GitHub Pages

## Testing
- `actionlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ef1fff414832cb1b8f2008e10c1d1