### PR TITLE
Add client generation workflow

### DIFF
--- a/.github/workflows/_client-gen.yml
+++ b/.github/workflows/_client-gen.yml
@@ -1,0 +1,38 @@
+name: OpenAPI client generation
+
+on:
+  workflow_call:
+    inputs:
+      language:
+        required: true
+        type: string
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache build tools
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.npm
+            ~/.cargo/registry
+            ~/.gem
+          key: ${{ runner.os }}-${{ inputs.language }}-client-gen
+
+      - name: Install openapi-generator-cli
+        uses: OpenAPITools/openapi-generator-cli@v1
+
+      - name: Generate ${{ inputs.language }} client
+        run: |
+          openapi-generator-cli generate -g ${{ inputs.language }} -i imednet/openapi.yaml -o clients/${{ inputs.language }}
+
+      - name: Upload generated client
+        uses: actions/upload-artifact@v3
+        with:
+          name: client-${{ inputs.language }}
+          path: clients/${{ inputs.language }}
+

--- a/.github/workflows/openapi-imednet.yml
+++ b/.github/workflows/openapi-imednet.yml
@@ -14,3 +14,22 @@ jobs:
       - name: Validate iMednet specification
         run: |
           docker run --rm -v ${{ github.workspace }}:/local openapitools/openapi-generator-cli validate -i /local/imednet/openapi.yaml
+
+  generate_clients:
+    needs: validate-imednet
+    strategy:
+      matrix:
+        lang:
+          - java
+          - javascript
+          - python
+          - ruby
+          - r
+          - rust
+          - cpprest
+          - go
+          - csharp
+          - c
+    uses: ./.github/workflows/_client-gen.yml
+    with:
+      language: ${{ matrix.lang }}

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This repository hosts OpenAPI specifications for two clinical research platforms
 
 - **iMednet EDC API**: see `imednet/openapi.yaml` and the accompanying RST documentation under `imednet/api_docs`.
 
-GitHub Actions workflows validate the specifications automatically when the specification file changes.
+GitHub Actions workflows validate the specifications automatically when the specification file changes. After a successful validation, reusable jobs generate language specific SDKs and upload them as build artifacts.


### PR DESCRIPTION
## Summary
- create reusable client-generation workflow with caching and artifact upload
- run matrix of languages after validation
- mention new SDK generation in README

## Testing
- `docker run` failed: `command not found`

------
https://chatgpt.com/codex/tasks/task_e_686ef1a65c64832c9b7859cb593094ec