### PR TITLE
Add docs branch and update workflow

### DIFF
--- a/.github/workflows/api-docs-and-java.yml
+++ b/.github/workflows/api-docs-and-java.yml
@@ -1,0 +1,83 @@
+name: api-docs-and-java
+on:
+  push:
+    paths:
+      - "imednet/**/*.y{a,}ml"
+    branches-ignore:
+      - generated-docs
+      - generated-java-client
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: stoplightio/spectral-action@v1
+        with:
+          file_glob: imednet/**/*.yaml
+
+  docs:
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+      - run: npx redoc-cli@0.15.1 bundle imednet/openapi.yaml -o site/index.html
+      - uses: actions/upload-pages-artifact@v3.0.1
+        with:
+          path: site
+      - uses: actions/deploy-pages@v4
+      - name: Update generated-docs branch
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git fetch origin
+          git checkout -B generated-docs
+          git add site
+          git commit -m "Update generated docs" || echo "No changes"
+          git push origin generated-docs
+
+  java-client:
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate client
+        uses: openapi-generators/openapitools-generator-action@v1.5.0
+        with:
+          generator: java
+          openapi-file: imednet/openapi.yaml
+          output-dir: clients/java
+      - uses: actions/upload-artifact@v4
+        with:
+          name: client-java
+          path: clients/java
+      - name: Update generated-java-client branch
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git fetch origin
+          git checkout -B generated-java-client
+          git add clients/java
+          git commit -m "Update generated Java client" || echo "No changes"
+          git push origin generated-java-client
+      - name: Checkout client repository
+        uses: actions/checkout@v4
+        with:
+          repository: owner/java-client-repo
+          token: ${{ secrets.CLIENT_REPO_TOKEN }}
+          path: java-client-repo
+      - name: Sync generated Java client
+        run: |
+          rsync -av --delete --exclude '.git' clients/java/ java-client-repo/
+      - name: Create PR with updated client
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.CLIENT_REPO_TOKEN }}
+          path: java-client-repo
+          commit-message: Update generated Java client
+          title: Update generated Java client
+          body: |
+            Automated update of the Java client generated from the latest API specification.
+          branch: update-java-client
+          delete-branch: true


### PR DESCRIPTION
## Summary
- push generated docs to a dedicated branch
- ignore generated-docs branch so the workflow doesn't self-trigger

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ef64336c0832c85a7adefe997f64c