### PR TITLE
Fix OpenAPI client generation workflow

### DIFF
--- a/.github/workflows/generate-clients.yml
+++ b/.github/workflows/generate-clients.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           generator: ${{ matrix.lang }}
           openapi-file: imednet/openapi.yaml
-          output-dir: client/${{ matrix.lang }}
+          command-args: -o client/${{ matrix.lang }}
 
       - name: Ensure client code exists
         run: |

--- a/imednet/openapi.yaml
+++ b/imednet/openapi.yaml
@@ -8,7 +8,7 @@ info:
     the API.
 
     '
-  version: 1.0.13
+  version: 1.0.14
 servers:
 - url: https://edc.prod.imednetapi.com/api/v1/edc
   description: Production EDC API server


### PR DESCRIPTION
## Summary
- use `command-args` instead of invalid `output-dir` when calling openapitools generator action

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686fe229c8e0832cb08773f942da6d80