### PR TITLE
Update openapi specification with v2 features

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -9,7 +9,7 @@ info:
     the API.
 
     '
-  version: 1.0.14
+  version: 1.0.15
 servers:
 - url: https://edc.prod.imednetapi.com/api/v1/edc
   description: Production EDC API server

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1,4 +1,5 @@
 openapi: 3.1.0
+jsonSchemaDialect: "https://spec.openapis.org/oas/3.1/dialect/base"
 info:
   title: Mednet EDC API
   description: 'The Mednet EDC (Electronic Data Capture) REST API provides a single-point
@@ -12,14 +13,43 @@ info:
 servers:
 - url: https://edc.prod.imednetapi.com/api/v1/edc
   description: Production EDC API server
+security:
+  - apiKeyAuth: []
+    securityKeyAuth: []
+tags:
+  - name: Studies
+    description: "Operations related to retrieving studies accessible via the API key."
+  - name: Sites
+    description: "Operations related to site management and retrieval within a study."
+  - name: Subjects
+    description: "Operations for retrieving subject (participant) information within a study."
+  - name: Forms
+    description: "Operations for retrieving form (eCRF) definitions and metadata in a study."
+  - name: Variables
+    description: "Operations for retrieving variable (field) definitions for study forms."
+  - name: Intervals
+    description: "Operations for retrieving visit schedule definitions (intervals) in a study."
+  - name: Visits
+    description: "Operations for retrieving subject visit instances recorded in a study."
+  - name: Records
+    description: "Operations for retrieving and submitting study record data (eCRF records)."
+  - name: Record Revisions
+    description: "Operations for retrieving audit trail entries (record revisions) in a study."
+  - name: Queries
+    description: "Operations for retrieving data queries and their history in a study."
+  - name: Codings
+    description: "Operations for retrieving coded data entries (e.g., coded terms) in a study."
+  - name: Administration
+    description: "Administrative operations, such as listing users and their roles in a study."
+  - name: Jobs
+    description: "Operations for checking the status of asynchronous jobs (e.g., data import jobs)."
 paths:
   /studies:
     get:
+      tags:
+      - Studies
       summary: List studies accessible by API key
       operationId: listStudies
-      security:
-      - apiKeyAuth: []
-        securityKeyAuth: []
       parameters:
       - $ref: '#/components/parameters/PageParam'
       - $ref: '#/components/parameters/SizeParam'
@@ -31,17 +61,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  metadata:
-                    $ref: '#/components/schemas/Metadata'
-                  pagination:
-                    $ref: '#/components/schemas/Pagination'
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Study'
-                title: listStudies_200_response
+                $ref: '#/components/schemas/StudyList'
               examples:
                 studiesList:
                   $ref: '#/components/examples/ExampleStudiesList'
@@ -57,11 +77,10 @@ paths:
           $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}/sites:
     get:
+      tags:
+      - Sites
       summary: List sites for a study
       operationId: listSites
-      security:
-      - apiKeyAuth: []
-        securityKeyAuth: []
       parameters:
       - $ref: '#/components/parameters/StudyKeyPath'
       - $ref: '#/components/parameters/PageParam'
@@ -74,17 +93,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  metadata:
-                    $ref: '#/components/schemas/Metadata'
-                  pagination:
-                    $ref: '#/components/schemas/Pagination'
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Site'
-                title: listSites_200_response
+                $ref: '#/components/schemas/SiteList'
               examples:
                 sitesList:
                   $ref: '#/components/examples/ExampleSitesList'
@@ -100,11 +109,10 @@ paths:
           $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}/forms:
     get:
+      tags:
+      - Forms
       summary: List forms in a study
       operationId: listForms
-      security:
-      - apiKeyAuth: []
-        securityKeyAuth: []
       parameters:
       - $ref: '#/components/parameters/StudyKeyPath'
       - $ref: '#/components/parameters/PageParam'
@@ -117,17 +125,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  metadata:
-                    $ref: '#/components/schemas/Metadata'
-                  pagination:
-                    $ref: '#/components/schemas/Pagination'
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Form'
-                title: listForms_200_response
+                $ref: '#/components/schemas/FormList'
               examples:
                 formsList:
                   $ref: '#/components/examples/ExampleFormsList'
@@ -143,11 +141,10 @@ paths:
           $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}/intervals:
     get:
+      tags:
+      - Intervals
       summary: List intervals (visit definitions) in a study
       operationId: listIntervals
-      security:
-      - apiKeyAuth: []
-        securityKeyAuth: []
       parameters:
       - $ref: '#/components/parameters/StudyKeyPath'
       - $ref: '#/components/parameters/PageParam'
@@ -160,17 +157,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  metadata:
-                    $ref: '#/components/schemas/Metadata'
-                  pagination:
-                    $ref: '#/components/schemas/Pagination'
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Interval'
-                title: listIntervals_200_response
+                $ref: '#/components/schemas/IntervalList'
               examples:
                 intervalsList:
                   $ref: '#/components/examples/ExampleIntervalsList'
@@ -186,11 +173,10 @@ paths:
           $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}/visits:
     get:
+      tags:
+      - Visits
       summary: List visits (subject visit instances) in a study
       operationId: listVisits
-      security:
-      - apiKeyAuth: []
-        securityKeyAuth: []
       parameters:
       - $ref: '#/components/parameters/StudyKeyPath'
       - $ref: '#/components/parameters/PageParam'
@@ -203,17 +189,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  metadata:
-                    $ref: '#/components/schemas/Metadata'
-                  pagination:
-                    $ref: '#/components/schemas/Pagination'
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Visit'
-                title: listVisits_200_response
+                $ref: '#/components/schemas/VisitList'
               examples:
                 visitsList:
                   $ref: '#/components/examples/ExampleVisitsList'
@@ -229,11 +205,10 @@ paths:
           $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}/subjects:
     get:
+      tags:
+      - Subjects
       summary: List subjects in a study
       operationId: listSubjects
-      security:
-      - apiKeyAuth: []
-        securityKeyAuth: []
       parameters:
       - $ref: '#/components/parameters/StudyKeyPath'
       - $ref: '#/components/parameters/PageParam'
@@ -246,17 +221,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  metadata:
-                    $ref: '#/components/schemas/Metadata'
-                  pagination:
-                    $ref: '#/components/schemas/Pagination'
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Subject'
-                title: listSubjects_200_response
+                $ref: '#/components/schemas/SubjectList'
               examples:
                 subjectsList:
                   $ref: '#/components/examples/ExampleSubjectsList'
@@ -272,11 +237,10 @@ paths:
           $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}/users:
     get:
+      tags:
+      - Administration
       summary: List users and their roles in a study
       operationId: listUsers
-      security:
-      - apiKeyAuth: []
-        securityKeyAuth: []
       parameters:
       - $ref: '#/components/parameters/StudyKeyPath'
       - $ref: '#/components/parameters/PageParam'
@@ -289,17 +253,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  metadata:
-                    $ref: '#/components/schemas/Metadata'
-                  pagination:
-                    $ref: '#/components/schemas/Pagination'
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/User'
-                title: listUsers_200_response
+                $ref: '#/components/schemas/UserList'
               examples:
                 usersList:
                   $ref: '#/components/examples/ExampleUsersList'
@@ -315,11 +269,10 @@ paths:
           $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}/variables:
     get:
+      tags:
+      - Variables
       summary: List variables (fields) in a study
       operationId: listVariables
-      security:
-      - apiKeyAuth: []
-        securityKeyAuth: []
       parameters:
       - $ref: '#/components/parameters/StudyKeyPath'
       - $ref: '#/components/parameters/PageParam'
@@ -332,17 +285,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  metadata:
-                    $ref: '#/components/schemas/Metadata'
-                  pagination:
-                    $ref: '#/components/schemas/Pagination'
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Variable'
-                title: listVariables_200_response
+                $ref: '#/components/schemas/VariableList'
               examples:
                 variablesList:
                   $ref: '#/components/examples/ExampleVariablesList'
@@ -358,11 +301,10 @@ paths:
           $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}/codings:
     get:
+      tags:
+      - Codings
       summary: List coding activities in a study
       operationId: listCodings
-      security:
-      - apiKeyAuth: []
-        securityKeyAuth: []
       parameters:
       - $ref: '#/components/parameters/StudyKeyPath'
       - $ref: '#/components/parameters/PageParam'
@@ -375,17 +317,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  metadata:
-                    $ref: '#/components/schemas/Metadata'
-                  pagination:
-                    $ref: '#/components/schemas/Pagination'
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Coding'
-                title: listCodings_200_response
+                $ref: '#/components/schemas/CodingList'
               examples:
                 codingsList:
                   $ref: '#/components/examples/ExampleCodingsList'
@@ -401,11 +333,10 @@ paths:
           $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}/queries:
     get:
+      tags:
+      - Queries
       summary: List data queries in a study
       operationId: listQueries
-      security:
-      - apiKeyAuth: []
-        securityKeyAuth: []
       parameters:
       - $ref: '#/components/parameters/StudyKeyPath'
       - $ref: '#/components/parameters/PageParam'
@@ -418,17 +349,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  metadata:
-                    $ref: '#/components/schemas/Metadata'
-                  pagination:
-                    $ref: '#/components/schemas/Pagination'
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Query'
-                title: listQueries_200_response
+                $ref: '#/components/schemas/QueryList'
               examples:
                 queriesList:
                   $ref: '#/components/examples/ExampleQueriesList'
@@ -444,11 +365,10 @@ paths:
           $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}/recordRevisions:
     get:
+      tags:
+      - "Record Revisions"
       summary: List record revisions (audit trail entries) in a study
       operationId: listRecordRevisions
-      security:
-      - apiKeyAuth: []
-        securityKeyAuth: []
       parameters:
       - $ref: '#/components/parameters/StudyKeyPath'
       - $ref: '#/components/parameters/PageParam'
@@ -461,17 +381,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  metadata:
-                    $ref: '#/components/schemas/Metadata'
-                  pagination:
-                    $ref: '#/components/schemas/Pagination'
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/RecordRevision'
-                title: listRecordRevisions_200_response
+                $ref: '#/components/schemas/RecordRevisionList'
               examples:
                 recordRevisionsList:
                   $ref: '#/components/examples/ExampleRecordRevisionsList'
@@ -487,11 +397,10 @@ paths:
           $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}/records:
     get:
+      tags:
+      - Records
       summary: List records (eCRF instances) in a study
       operationId: listRecords
-      security:
-      - apiKeyAuth: []
-        securityKeyAuth: []
       parameters:
       - $ref: '#/components/parameters/StudyKeyPath'
       - $ref: '#/components/parameters/PageParam'
@@ -505,17 +414,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  metadata:
-                    $ref: '#/components/schemas/Metadata'
-                  pagination:
-                    $ref: '#/components/schemas/Pagination'
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Record'
-                title: listRecords_200_response
+                $ref: '#/components/schemas/RecordList'
               examples:
                 recordsList:
                   $ref: '#/components/examples/ExampleRecordsList'
@@ -530,11 +429,10 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
     post:
+      tags:
+      - Records
       summary: Add new record or update subject/record data
       operationId: createRecords
-      security:
-      - apiKeyAuth: []
-        securityKeyAuth: []
       parameters:
       - $ref: '#/components/parameters/StudyKeyPath'
       requestBody:
@@ -581,11 +479,10 @@ paths:
           $ref: '#/components/responses/InternalServerError'
   /studies/{studyKey}/jobs/{batchId}:
     get:
+      tags:
+      - Jobs
       summary: Retrieve job status by batch ID
       operationId: getJobStatus
-      security:
-      - apiKeyAuth: []
-        securityKeyAuth: []
       parameters:
       - $ref: '#/components/parameters/StudyKeyPath'
       - $ref: '#/components/parameters/BatchIdPath'
@@ -626,6 +523,7 @@ components:
           description: Requested URI path
         timestamp:
           type: string
+          format: date-time
           description: Timestamp when response was generated
         error:
           type: object
@@ -665,6 +563,7 @@ components:
           description: Name of the property by which the result is sorted
         direction:
           type: string
+          enum: [ASC, DESC]
           description: Sort direction (ASC or DESC)
       title: Sort
     Study:
@@ -1044,6 +943,7 @@ components:
           description: Mednet variable ID
         variableType:
           type: string
+          enum: [TEXT, TEXTAREA, RADIO, CHECKBOX, DROPDOWN, DATE, NUMBER]
           description: Type of the variable (field type), e.g., RADIO, TEXT, etc.
         variableName:
           type: string
@@ -1441,6 +1341,150 @@ components:
           type: string
           description: Timestamp when the job finished processing
       title: Job
+    StudyList:
+      type: object
+      properties:
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Study'
+      title: StudyList
+    SiteList:
+      type: object
+      properties:
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Site'
+      title: SiteList
+    FormList:
+      type: object
+      properties:
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Form'
+      title: FormList
+    IntervalList:
+      type: object
+      properties:
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Interval'
+      title: IntervalList
+    VisitList:
+      type: object
+      properties:
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Visit'
+      title: VisitList
+    SubjectList:
+      type: object
+      properties:
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Subject'
+      title: SubjectList
+    UserList:
+      type: object
+      properties:
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/User'
+      title: UserList
+    VariableList:
+      type: object
+      properties:
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Variable'
+      title: VariableList
+    CodingList:
+      type: object
+      properties:
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Coding'
+      title: CodingList
+    QueryList:
+      type: object
+      properties:
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Query'
+      title: QueryList
+    RecordRevisionList:
+      type: object
+      properties:
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/RecordRevision'
+      title: RecordRevisionList
+    RecordList:
+      type: object
+      properties:
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Record'
+      title: RecordList
   parameters:
     StudyKeyPath:
       name: studyKey
@@ -1463,6 +1507,8 @@ components:
       schema:
         type: integer
         default: 0
+        minimum: 0
+        example: 0
     SizeParam:
       name: size
       in: query
@@ -1470,6 +1516,9 @@ components:
       schema:
         type: integer
         default: 25
+        minimum: 1
+        maximum: 500
+        example: 25
     SortParam:
       name: sort
       in: query
@@ -1517,7 +1566,6 @@ components:
       name: x-imn-security-key
       in: header
       description: Security key (secret) provided by iMednet
-  requestBodies: {}
   responses:
     BadRequest:
       description: Bad request (malformed or invalid input)
@@ -1604,7 +1652,6 @@ components:
                 status: ERROR
                 error:
                   message: An unexpected server error occurred. Please contact support.
-  headers: {}
   examples:
     ExampleStudiesList:
       summary: Example response for listing studies
@@ -1621,11 +1668,11 @@ components:
           totalPages: 1
           totalElements: 1
           sort:
-          - property: studyKey
-            direction: ASC
-        data:
-        - sponsorKey: '100'
-          studyKey: PHARMADEMO
+            - property: studyKey
+              direction: ASC
+          data:
+            - sponsorKey: '100'
+              studyKey: PHARMADEMO
           studyId: 100
           studyName: iMednet Pharma Demonstration Study
           studyDescription: iMednet Demonstration Study v2 Created 05April2018 After
@@ -1648,15 +1695,15 @@ components:
           totalPages: 1
           totalElements: 1
           sort:
-          - property: siteId
-            direction: ASC
+            - property: siteId
+              direction: ASC
         data:
-        - studyKey: PHARMADEMO
-          siteId: 1
-          siteName: Mock Site 1
-          siteEnrollmentStatus: Enrollment Open
-          dateCreated: '2025-06-05 21:12:09'
-          dateModified: '2025-06-05 21:12:10'
+          - studyKey: PHARMADEMO
+            siteId: 1
+            siteName: Mock Site 1
+            siteEnrollmentStatus: Enrollment Open
+            dateCreated: '2025-06-05 21:12:09'
+            dateModified: '2025-06-05 21:12:10'
     ExampleFormsList:
       summary: Example response for listing forms
       value:
@@ -1672,26 +1719,26 @@ components:
           totalPages: 1
           totalElements: 1
           sort:
-          - property: formId
-            direction: ASC
+            - property: formId
+              direction: ASC
         data:
-        - studyKey: PHARMADEMO
-          formId: 1
-          formKey: FORM_1
-          formName: Mock Form 1
-          formType: Subject
-          revision: 1
-          embeddedLog: false
-          enforceOwnership: false
-          userAgreement: false
-          subjectRecordReport: false
-          unscheduledVisit: false
-          otherForms: false
-          eproForm: false
-          allowCopy: true
-          disabled: false
-          dateCreated: '2025-06-05 21:12:09'
-          dateModified: '2025-06-05 21:12:10'
+          - studyKey: PHARMADEMO
+            formId: 1
+            formKey: FORM_1
+            formName: Mock Form 1
+            formType: Subject
+            revision: 1
+            embeddedLog: false
+            enforceOwnership: false
+            userAgreement: false
+            subjectRecordReport: false
+            unscheduledVisit: false
+            otherForms: false
+            eproForm: false
+            allowCopy: true
+            disabled: false
+            dateCreated: '2025-06-05 21:12:09'
+            dateModified: '2025-06-05 21:12:10'
     ExampleIntervalsList:
       summary: Example response for listing intervals
       value:
@@ -1707,33 +1754,33 @@ components:
           totalPages: 1
           totalElements: 1
           sort:
-          - property: intervalId
-            direction: ASC
+            - property: intervalId
+              direction: ASC
         data:
-        - studyKey: PHARMADEMO
-          intervalId: 1
-          intervalName: Day 1
-          intervalDescription: Day 1
-          intervalSequence: 110
-          intervalGroupId: 10
-          intervalGroupName: ePRO
-          disabled: true
-          dateCreated: '2025-06-05 21:12:08'
-          dateModified: '2025-06-05 21:12:09'
-          timeline: Start Date End Date
-          definedUsingInterval: Baseline
-          windowCalculationForm: Procedure
-          windowCalculationDate: PROCDT
-          actualDateForm: Follow Up
-          actualDate: FUDT
-          dueDateWillBeIn: 30
-          negativeSlack: 7
-          positiveSlack: 7
-          eproGracePeriod: 2
-          forms:
-          - formId: 123
-            formKey: MY-FORM-KEY
-            formName: myFormName
+          - studyKey: PHARMADEMO
+            intervalId: 1
+            intervalName: Day 1
+            intervalDescription: Day 1
+            intervalSequence: 110
+            intervalGroupId: 10
+            intervalGroupName: ePRO
+            disabled: true
+            dateCreated: '2025-06-05 21:12:08'
+            dateModified: '2025-06-05 21:12:09'
+            timeline: Start Date End Date
+            definedUsingInterval: Baseline
+            windowCalculationForm: Procedure
+            windowCalculationDate: PROCDT
+            actualDateForm: Follow Up
+            actualDate: FUDT
+            dueDateWillBeIn: 30
+            negativeSlack: 7
+            positiveSlack: 7
+            eproGracePeriod: 2
+            forms:
+              - formId: 123
+                formKey: MY-FORM-KEY
+                formName: myFormName
     ExampleVisitsList:
       summary: Example response for listing visits
       value:
@@ -1749,24 +1796,24 @@ components:
           totalPages: 1
           totalElements: 1
           sort:
-          - property: visitId
-            direction: ASC
+            - property: visitId
+              direction: ASC
         data:
-        - visitId: 1
-          studyKey: PHARMADEMO
-          intervalId: 13
-          intervalName: Day 15
-          subjectId: 247
-          subjectKey: 111-005
-          startDate: '2025-06-05'
-          endDate: '2025-06-12'
-          dueDate: null
-          visitDate: '2025-06-07'
-          visitDateForm: Follow Up
-          deleted: false
-          visitDateQuestion: AESEV
-          dateCreated: '2025-06-05 21:12:08'
-          dateModified: '2025-06-05 21:12:08'
+          - visitId: 1
+            studyKey: PHARMADEMO
+            intervalId: 13
+            intervalName: Day 15
+            subjectId: 247
+            subjectKey: 111-005
+            startDate: '2025-06-05'
+            endDate: '2025-06-12'
+            dueDate: null
+            visitDate: '2025-06-07'
+            visitDateForm: Follow Up
+            deleted: false
+            visitDateQuestion: AESEV
+            dateCreated: '2025-06-05 21:12:08'
+            dateModified: '2025-06-05 21:12:08'
     ExampleSubjectsList:
       summary: Example response for listing subjects
       value:
@@ -1782,25 +1829,25 @@ components:
           totalPages: 1
           totalElements: 1
           sort:
-          - property: subjectId
-            direction: ASC
+            - property: subjectId
+              direction: ASC
         data:
-        - studyKey: PHARMADEMO
-          subjectId: 1
-          subjectOid: OID-1
-          subjectKey: 01-001
-          subjectStatus: Enrolled
-          siteId: 128
-          siteName: Chicago Hope Hospital
-          deleted: false
-          enrollmentStartDate: '2025-06-05 21:12:09'
-          dateCreated: '2025-06-05 21:12:09'
-          dateModified: '2025-06-05 21:12:10'
-          keywords:
-          - keywordName: Data Entry Error
-            keywordKey: DEE
-            keywordId: 15362
-            dateAdded: '2025-06-05 21:12:09'
+          - studyKey: PHARMADEMO
+            subjectId: 1
+            subjectOid: OID-1
+            subjectKey: 01-001
+            subjectStatus: Enrolled
+            siteId: 128
+            siteName: Chicago Hope Hospital
+            deleted: false
+            enrollmentStartDate: '2025-06-05 21:12:09'
+            dateCreated: '2025-06-05 21:12:09'
+            dateModified: '2025-06-05 21:12:10'
+            keywords:
+              - keywordName: Data Entry Error
+                keywordKey: DEE
+                keywordId: 15362
+                dateAdded: '2025-06-05 21:12:09'
     ExampleUsersList:
       summary: Example response for listing users
       value:
@@ -1816,62 +1863,62 @@ components:
           totalPages: 1
           totalElements: 1
           sort:
-          - property: login
-            direction: ASC
+            - property: login
+              direction: ASC
         data:
-        - userId: 685253e1-1a95-4352-a7b0-4c62d3807727
-          login: wsmith1
-          firstName: William
-          lastName: Smith
-          email: wsmith@mednet.com
-          userActiveInStudy: true
-          roles:
-          - dateCreated:
-            - 2025
-            - 6
-            - 5
-            - 21
-            - 12
-            - 7
-            - 625000000
-            dateModified:
-            - 2025
-            - 6
-            - 5
-            - 21
-            - 12
-            - 7
-            - 625000000
-            roleId: 6ec2a32b-143c-43d3-b562-9d902a61f884
-            communityId: 1
-            name: Role name 1
-            description: Role description 1
-            level: 1
-            type: Role type 1
-            inactive: false
-          - dateCreated:
-            - 2025
-            - 6
-            - 5
-            - 21
-            - 12
-            - 7
-            - 625000000
-            dateModified:
-            - 2025
-            - 6
-            - 5
-            - 21
-            - 12
-            - 7
-            - 625000000
-            roleId: 6ec2a32b-143c-43d3-b562-9d902a61f884
-            communityId: 2
-            name: Role name 2
-            description: Role description 2
-            level: 2
-            type: Role type 2
-            inactive: false
+          - userId: 685253e1-1a95-4352-a7b0-4c62d3807727
+            login: wsmith1
+            firstName: William
+            lastName: Smith
+            email: wsmith@mednet.com
+            userActiveInStudy: true
+            roles:
+              - dateCreated:
+                  - 2025
+                  - 6
+                  - 5
+                  - 21
+                  - 12
+                  - 7
+                  - 625000000
+                dateModified:
+                  - 2025
+                  - 6
+                  - 5
+                  - 21
+                  - 12
+                  - 7
+                  - 625000000
+                roleId: 6ec2a32b-143c-43d3-b562-9d902a61f884
+                communityId: 1
+                name: Role name 1
+                description: Role description 1
+                level: 1
+                type: Role type 1
+                inactive: false
+              - dateCreated:
+                  - 2025
+                  - 6
+                  - 5
+                  - 21
+                  - 12
+                  - 7
+                  - 625000000
+                dateModified:
+                  - 2025
+                  - 6
+                  - 5
+                  - 21
+                  - 12
+                  - 7
+                  - 625000000
+                roleId: 6ec2a32b-143c-43d3-b562-9d902a61f884
+                communityId: 2
+                name: Role name 2
+                description: Role description 2
+                level: 2
+                type: Role type 2
+                inactive: false
     ExampleVariablesList:
       summary: Example response for listing variables
       value:
@@ -1887,25 +1934,25 @@ components:
           totalPages: 1
           totalElements: 1
           sort:
-          - property: variableId
-            direction: ASC
+            - property: variableId
+              direction: ASC
         data:
-        - studyKey: PHARMADEMO
-          variableId: 1
-          variableType: RADIO
-          variableName: Pain Level
-          sequence: 1
-          revision: 1
-          disabled: false
-          dateCreated: '2025-06-05 21:12:08'
-          dateModified: '2025-06-05 21:12:09'
-          formId: 108727
-          variableOid: OID-1
-          deleted: false
-          formKey: FORM_1
-          formName: Pre-procedure screening
-          label: Select patient pain level between 1 and 10
-          blinded: false
+          - studyKey: PHARMADEMO
+            variableId: 1
+            variableType: RADIO
+            variableName: Pain Level
+            sequence: 1
+            revision: 1
+            disabled: false
+            dateCreated: '2025-06-05 21:12:08'
+            dateModified: '2025-06-05 21:12:09'
+            formId: 108727
+            variableOid: OID-1
+            deleted: false
+            formKey: FORM_1
+            formName: Pre-procedure screening
+            label: Select patient pain level between 1 and 10
+            blinded: false
     ExampleCodingsList:
       summary: Example response for listing codings
       value:
@@ -1921,28 +1968,28 @@ components:
           totalPages: 1
           totalElements: 1
           sort:
-          - property: recordId
-            direction: ASC
+            - property: recordId
+              direction: ASC
         data:
-        - studyKey: PHARMADEMO
-          siteName: Chicago Hope Hospital
-          siteId: 128
-          subjectId: 247
-          subjectKey: 111-005
-          formId: 1
-          formName: Adverse Event
-          formKey: AE
-          revision: 2
-          recordId: 1
-          variable: AETERM
-          value: Angina
-          codingId: 1
-          code: Angina agranulocytic
-          codedBy: John Smith
-          reason: Typo fix
-          dictionaryName: MedDRA
-          dictionaryVersion: '24.0'
-          dateCoded: '2025-06-05 21:12:10'
+          - studyKey: PHARMADEMO
+            siteName: Chicago Hope Hospital
+            siteId: 128
+            subjectId: 247
+            subjectKey: 111-005
+            formId: 1
+            formName: Adverse Event
+            formKey: AE
+            revision: 2
+            recordId: 1
+            variable: AETERM
+            value: Angina
+            codingId: 1
+            code: Angina agranulocytic
+            codedBy: John Smith
+            reason: Typo fix
+            dictionaryName: MedDRA
+            dictionaryVersion: '24.0'
+            dateCoded: '2025-06-05 21:12:10'
     ExampleQueriesList:
       summary: Example response for listing queries
       value:
@@ -1958,28 +2005,28 @@ components:
           totalPages: 1
           totalElements: 1
           sort:
-          - property: annotationId
-            direction: ASC
+            - property: annotationId
+              direction: ASC
         data:
-        - studyKey: PHARMADEMO
-          subjectId: 1
-          subjectOid: OID-1
-          annotationType: subject
-          annotationId: 1
-          type: null
-          description: Monitor Query
-          recordId: 123
-          variable: aeterm
-          subjectKey: 123-005
-          dateCreated: '2025-06-05 21:12:09'
-          dateModified: '2025-06-05 21:12:10'
-          queryComments:
-          - sequence: 1
-            annotationStatus: Monitor Query Open
-            user: john
-            comment: Added comment to study
-            closed: false
-            date: '2025-06-05 21:12:09'
+          - studyKey: PHARMADEMO
+            subjectId: 1
+            subjectOid: OID-1
+            annotationType: subject
+            annotationId: 1
+            type: null
+            description: Monitor Query
+            recordId: 123
+            variable: aeterm
+            subjectKey: 123-005
+            dateCreated: '2025-06-05 21:12:09'
+            dateModified: '2025-06-05 21:12:10'
+            queryComments:
+              - sequence: 1
+                annotationStatus: Monitor Query Open
+                user: john
+                comment: Added comment to study
+                closed: false
+                date: '2025-06-05 21:12:09'
     ExampleRecordRevisionsList:
       summary: Example response for listing record revisions
       value:
@@ -1995,27 +2042,27 @@ components:
           totalPages: 1
           totalElements: 1
           sort:
-          - property: recordRevisionId
-            direction: ASC
+            - property: recordRevisionId
+              direction: ASC
         data:
-        - studyKey: PHARMADEMO
-          recordRevisionId: 1
-          recordId: 1
-          recordOid: REC-1
-          recordRevision: 1
-          dataRevision: 1
-          recordStatus: Record Complete
-          subjectId: 247
-          subjectOid: OID-1
-          subjectKey: 001-003
-          siteId: 2
-          formKey: AE
-          intervalId: 15
-          role: Research Coordinator
-          user: jdoe
-          reasonForChange: Data entry error
-          deleted: true
-          dateCreated: '2025-06-05 21:12:09'
+          - studyKey: PHARMADEMO
+            recordRevisionId: 1
+            recordId: 1
+            recordOid: REC-1
+            recordRevision: 1
+            dataRevision: 1
+            recordStatus: Record Complete
+            subjectId: 247
+            subjectOid: OID-1
+            subjectKey: 001-003
+            siteId: 2
+            formKey: AE
+            intervalId: 15
+            role: Research Coordinator
+            user: jdoe
+            reasonForChange: Data entry error
+            deleted: true
+            dateCreated: '2025-06-05 21:12:09'
     ExampleRecordsList:
       summary: Example response for listing records
       value:
@@ -2031,37 +2078,37 @@ components:
           totalPages: 1
           totalElements: 1
           sort:
-          - property: recordId
-            direction: ASC
+            - property: recordId
+              direction: ASC
         data:
-        - studyKey: PHARMADEMO
-          intervalId: 99
-          formId: 10202
-          formKey: AE
-          siteId: 128
-          recordId: 1
-          recordOid: REC-1
-          recordType: SUBJECT
-          recordStatus: Record Incomplete
-          deleted: false
-          dateCreated: '2025-06-05 21:12:09'
-          dateModified: '2025-06-05 21:12:10'
-          subjectId: 326
-          subjectOid: OID-1
-          subjectKey: 123-456
-          visitId: 1
-          parentRecordId: 34
-          keywords:
-          - keywordName: Data Entry Error
-            keywordKey: DEE
-            keywordId: 15362
-            dateAdded: '2025-06-05 21:12:09'
-          recordData:
-            dateCreated: '2018-10-18 06:21:46'
-            unvnum: '1'
-            dateModified: '2018-11-18 07:11:16'
-            aeser: ''
-            aeterm: Bronchitis
+          - studyKey: PHARMADEMO
+            intervalId: 99
+            formId: 10202
+            formKey: AE
+            siteId: 128
+            recordId: 1
+            recordOid: REC-1
+            recordType: SUBJECT
+            recordStatus: Record Incomplete
+            deleted: false
+            dateCreated: '2025-06-05 21:12:09'
+            dateModified: '2025-06-05 21:12:10'
+            subjectId: 326
+            subjectOid: OID-1
+            subjectKey: 123-456
+            visitId: 1
+            parentRecordId: 34
+            keywords:
+              - keywordName: Data Entry Error
+                keywordKey: DEE
+                keywordId: 15362
+                dateAdded: '2025-06-05 21:12:09'
+            recordData:
+              dateCreated: '2018-10-18 06:21:46'
+              unvnum: '1'
+              dateModified: '2018-11-18 07:11:16'
+              aeser: ''
+              aeterm: Bronchitis
     ExampleRegisterSubjectRequest:
       summary: Example request body for registering a new subject (via Registration
         form)
@@ -2107,4 +2154,3 @@ components:
         studyKey: $request.path.studyKey
         batchId: $response.body#/batchId
       description: Link to check the status of the job created by the record POST
-  callbacks: {}


### PR DESCRIPTION
## Summary
- apply v2 improvements to the OpenAPI spec
- declare JSON schema dialect
- centralize security configuration and define tags
- introduce list wrapper schemas
- add enum/format details and parameter constraints
- clean up examples and remove unused placeholders

## Testing
- `npx swagger-cli validate spec/openapi.yaml`

------
https://chatgpt.com/codex/tasks/task_e_687015db3a78832c831c421ad0e15c48